### PR TITLE
Updated chrome app manifest to allow new chrome.sockets API

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -34,6 +34,17 @@
     "http://*/*",
     "contextMenus"
   ],
-
+  "sockets": {
+     "udp": {
+       "bind": "*",
+       "send": "*"
+     },
+     "tcp": {
+       "connect": "*"
+     },
+     "tcpServer": {
+       "listen": "*"
+     }
+   },
   "offline_enabled": true
 }


### PR DESCRIPTION
Other modules began using the new chrome.sockets API: https://github.com/feross/webtorrent/issues/34,
however manifest for chrome app didn't allow it and wouldn't start. 
