### PR TITLE
arg was not defined. Might be a silly typo

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -54,7 +54,7 @@ if (!url) {
 
 var VLC_ARGS = '-q --video-on-top --play-and-exit'
 var OMX_EXEC = 'omxplayer -r -o ' + (typeof argv.omx === 'string')
-  ? arg.omx + ' '
+  ? argv.omx + ' '
   : 'hdmi '
 var MPLAYER_EXEC = 'mplayer -ontop -really-quiet -noidx -loop 0 '
 


### PR DESCRIPTION
Kept throwing 

```
~/Projects/Git/Github/webtorrent/bin/cmd.js:57
    ? arg.omx + ' '
    ^
ReferenceError: arg is not defined
    at Object.<anonymous> (/home/shyam/Projects/Git/Github/webtorrent/bin/cmd.js:57:5)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:902:3`
```
