### PR TITLE
Support `FileList` as input for the `seed` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,6 +199,11 @@ WebTorrent.prototype.seed = function (input, opts, onseed) {
     onseed = opts
     opts = {}
   }
+
+  if (typeof FileList === 'function' && input instanceof FileList) {
+    input = Array.prototype.slice.call(input)
+  }
+
   // TODO: support `input` as filesystem path string
   var buffer = Buffer.concat(input.map(function (file) {
     return file.buffer


### PR DESCRIPTION
The W3C `FileList` object has no `map` method, thus it needs to be converted to an array before using.

Otherwise I got `input.map is not a function` with the following code:

``` js
var WebTorrent = require('webtorrent')

var client = new WebTorrent()

// `input` is a file input
input.onchange = function (e) {
  client.seed(e.target.files, function (torrent) {
    console.log('Torrent info hash:', torrent.infoHash)
  })
}
```
