### PR TITLE
dynamic requests pipeline length

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -21,10 +21,12 @@ var ut_metadata = require('ut_metadata')
 var ut_pex = require('ut_pex') // browser exclude
 
 var MAX_BLOCK_LENGTH = 128 * 1024
-var MAX_OUTSTANDING_REQUESTS = 5
 var PIECE_TIMEOUT = 10000
 var CHOKE_TIMEOUT = 5000
 var SPEED_THRESHOLD = 3 * Storage.BLOCK_LENGTH
+
+var PIPELINE_MIN_DURATION = 0.5
+var PIPELINE_MAX_DURATION = 1
 
 var RECHOKE_INTERVAL = 10000 // 10 seconds
 var RECHOKE_OPTIMISTIC_DURATION = 2 // 30 seconds
@@ -650,6 +652,10 @@ Torrent.prototype._updateWire = function (wire) {
   if (wire.peerChoking) return
   if (!wire.downloaded) return validateWire()
 
+  var minOutstandingRequests = getPipelineLength(wire, PIPELINE_MIN_DURATION)
+  if (wire.requests.length >= minOutstandingRequests) return true
+  var maxOutstandingRequests = getPipelineLength(wire, PIPELINE_MAX_DURATION)
+
   trySelectWire(false) || trySelectWire(true)
 
   function genPieceFilterFunc (start, end, tried, rank) {
@@ -696,7 +702,7 @@ Torrent.prototype._updateWire = function (wire) {
     var speed = wire.downloadSpeed() || 1
     if (speed > SPEED_THRESHOLD) return function () { return true }
 
-    var secs = MAX_OUTSTANDING_REQUESTS * Storage.BLOCK_LENGTH / speed
+    var secs = Math.max(1, wire.requests.length) * Storage.BLOCK_LENGTH / speed
     var tries = 10
     var ptr = 0
 
@@ -734,7 +740,7 @@ Torrent.prototype._updateWire = function (wire) {
   }
 
   function trySelectWire (hotswap) {
-    if (wire.requests.length >= MAX_OUTSTANDING_REQUESTS) return true
+    if (wire.requests.length >= maxOutstandingRequests) return true
     var rank = speedRanker()
 
     for (var i = 0; i < self._selections.length; i++) {
@@ -756,7 +762,7 @@ Torrent.prototype._updateWire = function (wire) {
           // request all non-reserved blocks in this piece
           while (self._request(wire, piece, self._critical[piece] || hotswap)) {}
 
-          if (wire.requests.length < MAX_OUTSTANDING_REQUESTS) {
+          if (wire.requests.length < maxOutstandingRequests) {
             tried[piece] = true
             tries++
             continue
@@ -772,7 +778,7 @@ Torrent.prototype._updateWire = function (wire) {
           // request all non-reserved blocks in piece
           while (self._request(wire, piece, self._critical[piece] || hotswap)) {}
 
-          if (wire.requests.length < MAX_OUTSTANDING_REQUESTS) continue
+          if (wire.requests.length < maxOutstandingRequests) continue
 
           if (next.priority) shufflePriority(i)
           return true
@@ -915,7 +921,8 @@ Torrent.prototype._request = function (wire, index, hotswap) {
   var numRequests = wire.requests.length
 
   if (self.storage.bitfield.get(index)) return false
-  if (numRequests >= MAX_OUTSTANDING_REQUESTS) return false
+  var maxOutstandingRequests = getPipelineLength(wire, PIPELINE_MAX_DURATION)
+  if (numRequests >= maxOutstandingRequests) return false
 
   var endGame = (wire.requests.length === 0 && self.storage.numMissing < 30)
   var block = self.storage.reserveBlock(index, endGame)
@@ -970,6 +977,10 @@ Torrent.prototype.createServer = function (opts) {
   if (typeof Server === 'function' /* browser exclude */) {
     return new Server(self, opts)
   }
+}
+
+function getPipelineLength (wire, duration) {
+  return Math.ceil(2 + duration * wire.downloadSpeed() / Storage.BLOCK_LENGTH);
 }
 
 /**


### PR DESCRIPTION
With the fixed `MAX_OUTSTANDING_REQUESTS` we're running into the following problems when peer communication suffers from delay:
- High-bandwidth connections become stop'n'go because there are no queued requests while the previous requests' data is still in-flight.
- Low-bandwidth peers will have requests queued that will arrive much in the future, affording for the intelligent piece selection that is approached in `Torrent.prototype._updateWire()`. Unfortunately, this mechanism is difficult to understand, lacks documentation, and has multiple TODOs. I was observing quite a delay when seeking during streaming playback.

I propose using a pipeline length based on a bandwidth-delay-product. Because we cannot measure delay properly in pipelined TCP communication, we assume a constant of half a second. Large enough to avoid jitter on TCP packet loss for most links, small enough to retain agility when reselecting (seeking in streams). There's a lower limit (`PIPELINE_MIN_DURATION`) and an upper limit (`PIPELINE_MAX_DURATION`) to send requests in batches, thereby making use of the Nagle algorithm.

By confining the pipeline length in a time-based way I think you could throw away a lot of calculation in `speedRanker()`. Of course there's a downside with high-latency links, but it will still work with the minimum of 3 in-flight requests.

The terminology is arbitrary, feel free to rename `getPipelineLength()` to something else.
