### PR TITLE
Fixed Uncaught TypeError

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,6 +194,7 @@ WebTorrent.prototype.seed = function (input, opts, onseed) {
     onseed = opts
     opts = {}
   }
+  opts = opts || {}
 
   // TODO: support `input` as string, or array of strings
 


### PR DESCRIPTION
I was getting `Uncaught TypeError: Cannot read property 'name' of undefined` with `client.seed(files)` in the browser.

The error was being thrown in the `createTorrent` module: `opts.name` is read from without checking if `opts` exists. Should this fix should go in the `create-torrent` module?
