### PR TITLE
support .torrent urls with gzip/deflate response

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -6,19 +6,18 @@ var debug = require('debug')('webtorrent:torrent')
 var Discovery = require('torrent-discovery')
 var EventEmitter = require('events').EventEmitter
 var fs = require('fs') // browser exclude
-var hh = require('http-https') // browser exclude
+var get = require('simple-get') // browser exclude
 var inherits = require('inherits')
-var once = require('once')
 var parallel = require('run-parallel')
 var parseTorrent = require('parse-torrent')
-var RarityMap = require('./rarity-map')
 var reemit = require('re-emitter')
-var Server = require('./server') // browser exclude
-var Storage = require('./storage')
 var Swarm = require('bittorrent-swarm') // `webtorrent-swarm` in browser
-var url = require('url')
 var ut_metadata = require('ut_metadata')
 var ut_pex = require('ut_pex') // browser exclude
+
+var RarityMap = require('./rarity-map')
+var Server = require('./server') // browser exclude
+var Storage = require('./storage')
 
 var MAX_BLOCK_LENGTH = 128 * 1024
 var PIECE_TIMEOUT = 10000
@@ -77,12 +76,12 @@ function Torrent (torrentId, opts) {
   if (parsedTorrent && parsedTorrent.infoHash) {
     onTorrentId(parsedTorrent)
 
-  } else if (typeof hh.get === 'function' && /^https?:/.test(torrentId)) {
+  } else if (typeof get === 'function' && /^https?:/.test(torrentId)) {
     // http or https url to torrent file
-    httpGet(torrentId, function (err, torrent) {
+    get(torrentId, function (err, res) {
       if (err)
         return self.emit('error', new Error('error downloading torrent: ' + err.message))
-      onTorrentId(torrent)
+      res.pipe(concat(onTorrentId))
     })
 
   } else if (typeof fs.readFile === 'function') {
@@ -1007,34 +1006,4 @@ function randomizedForEach (array, cb) {
   indices.forEach(function (index) {
     cb(array[index], index, array)
   })
-}
-
-/**
- * Make http or https request, following redirects.
- * @param {string} u
- * @param {function} cb
- * @param {number=} maxRedirects
- * @return {http.ClientRequest}
- */
-function httpGet (u, cb, maxRedirects) {
-  cb = once(cb)
-  if (!maxRedirects) maxRedirects = 5
-  if (maxRedirects === 0) return cb(new Error('too many redirects'))
-
-  hh.get(u, function (res) {
-    // Check for redirect
-    if (res.statusCode >= 300 && res.statusCode < 400 && 'location' in res.headers) {
-      var location = res.headers.location
-      if (!url.parse(location).host) {
-        // If relative redirect, prepend host of current url
-        var parsed = url.parse(u)
-        location = parsed.protocol + '//' + parsed.host + location
-      }
-      res.resume() // discard response
-      return httpGet(location, cb, --maxRedirects)
-    }
-    res.pipe(concat(function (data) {
-      cb(null, data)
-    }))
-  }).on('error', cb)
 }

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   },
   "browser": {
     "./lib/fs-storage": false,
-    "./server": false,
     "./package.json": false,
+    "./server": false,
     "addr-to-ip-port": false,
     "bittorrent-dht/client": false,
     "bittorrent-swarm": "webtorrent-swarm",
     "concat-stream": false,
-    "http-https": false,
     "load-ip-set": false,
+    "simple-get": false,
     "ut_pex": false
   },
   "browserify": {
@@ -47,7 +47,6 @@
     "filestream": "^2.1.0",
     "git-sha1": "^0.1.2",
     "hat": "0.0.3",
-    "http-https": "^1.0.0",
     "inherits": "^2.0.1",
     "load-ip-set": "^1.0.3",
     "mime": "^1.2.11",
@@ -65,6 +64,7 @@
     "re-emitter": "^1.0.0",
     "rimraf": "^2.2.5",
     "run-parallel": "^1.0.0",
+    "simple-get": "^1.0.0",
     "speedometer": "^0.1.2",
     "thunky": "^0.1.0",
     "torrent-discovery": "^2.0.1",


### PR DESCRIPTION
Some servers always return a gzip response even when clients don't send `accept-encoding: gzip`. This PR adds support for such misbehaved servers, and also always requests gzipped responses.

Using the `simple-get` module (https://npmjs.org/package/simple-get), the lightest possible wrapper on top of core http, but also supporting:
- follow redirects
- automatically handle gzip/deflate responses
- supports HTTPS
