### PR TITLE
Add proxy options to allow proxying tracker and peer connections

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,9 +122,9 @@ function WebTorrent (opts) {
       if (!socksProxy.proxy.type) socksProxy.proxy.type = 5
 
       // Ensure electron-wrtc is used in electron with socks proxy
-      if (self.tracker && socksProxy && self.proxyOpts.proxyPeerConnections &&
+      if (self.tracker && self.proxyOpts.proxyPeerConnections &&
         process && process.versions['electron'] &&
-        (!self.tracker.wrtc || (self.tracker.wrtc && !self.tracker.wrtc.electronDaemon))) {
+        self.tracker.wrtc && !self.tracker.wrtc.electronDaemon) {
         console.warn('You need to provide an electron-wrtc instance in opts.wrtc to use Socks proxy in electron -> WebRTC is disabled')
         self.tracker.wrtc = false
       }

--- a/index.js
+++ b/index.js
@@ -113,6 +113,13 @@ function WebTorrent (opts) {
     self.proxyOpts.proxyTrackerConnections = self.proxyOpts.proxyTrackerConnections !== false
     self.proxyOpts.proxyPeerConnections = self.proxyOpts.proxyPeerConnections !== false
 
+    if (self.proxyOpts.proxyTrackerConnections && !self.tracker.proxyOpts) {
+      if (!self.tracker) {
+        self.tracker = {}
+      }
+      self.tracker.proxyOpts = self.proxyOpts
+    }
+
     if (self.proxyOpts.socksProxy) {
       if (!self.proxyOpts.socksProxy.proxy) self.proxyOpts.socksProxy.proxy = {}
       if (!self.proxyOpts.socksProxy.proxy.type) self.proxyOpts.socksProxy.proxy.type = 5

--- a/index.js
+++ b/index.js
@@ -113,10 +113,7 @@ function WebTorrent (opts) {
     self.proxyOpts.proxyTrackerConnections = self.proxyOpts.proxyTrackerConnections !== false
     self.proxyOpts.proxyPeerConnections = self.proxyOpts.proxyPeerConnections !== false
 
-    if (self.proxyOpts.proxyTrackerConnections && !self.tracker.proxyOpts) {
-      if (!self.tracker) {
-        self.tracker = {}
-      }
+    if (self.tracker && self.proxyOpts.proxyTrackerConnections && !self.tracker.proxyOpts) {
       self.tracker.proxyOpts = self.proxyOpts
     }
 

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ function WebTorrent (opts) {
       self.tracker.proxyOpts = self.proxyOpts
     }
 
-    var socksProxy = self.proxyOpts.socksProxy;
+    var socksProxy = self.proxyOpts.socksProxy
     if (socksProxy) {
       if (!socksProxy.proxy) socksProxy.proxy = {}
       if (!socksProxy.proxy.type) socksProxy.proxy.type = 5

--- a/index.js
+++ b/index.js
@@ -124,7 +124,8 @@ function WebTorrent (opts) {
       if (self.proxyOpts.socksProxy && self.proxyOpts.proxyPeerConnections &&
         process && process.versions['electron'] &&
         self.tracker.wrtc && !self.tracker.wrtc.electronDaemon) {
-        return self.emit('error', 'You need to provide an electron-wrtc instance in opts.wrtc to use socks in electron')
+        self.emit('error', 'You need to provide an electron-wrtc instance in opts.wrtc to use Socks proxy in electron -> WebRTC is disabled')
+        self.tracker.wrtc = false
       }
 
       // Convert proxy opts to electron API in webtorrent-hybrid
@@ -137,7 +138,9 @@ function WebTorrent (opts) {
           self.tracker.wrtc.electronDaemon.eval('window.webContents.session.setProxy(' +
                 JSON.stringify(electronConfig) + ', function(){})', networkSettingsReady)
         } else {
-          self.emit('error', 'SOCKS Proxy must be version 5 with no authentication to work in electron-wrtc')
+          self.emit('error', 'SOCKS Proxy must be version 5 with no authentication to work in electron-wrtc -> WebRTC is disabled')
+          self.tracker.wrtc = false
+          networkSettingsReady(null)
         }
       } else {
         networkSettingsReady(null)

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ var parseTorrent = require('parse-torrent')
 var path = require('path')
 var Peer = require('simple-peer')
 var randombytes = require('randombytes')
-var Socks = require('socks')
 var speedometer = require('speedometer')
 var zeroFill = require('zero-fill')
 
@@ -120,18 +119,6 @@ function WebTorrent (opts) {
     if (self.proxyOpts.socksProxy) {
       if (!self.proxyOpts.socksProxy.proxy) self.proxyOpts.socksProxy.proxy = {}
       if (!self.proxyOpts.socksProxy.proxy.type) self.proxyOpts.socksProxy.proxy.type = 5
-
-      // Create HTTP agents from socks proxy if needed
-      if (!self.proxyOpts.httpAgent) {
-        var httpOpts = extend(self.proxyOpts.socksProxy)
-        httpOpts.proxy = extend(opts.proxy)
-        self.proxyOpts.httpAgent = new Socks.Agent(httpOpts, false)
-      }
-      if (!self.proxyOpts.httpsAgent) {
-        var httpsOpts = extend(self.proxyOpts.socksProxy)
-        httpsOpts.proxy = extend(opts.proxy)
-        self.proxyOpts.httpsAgent = new Socks.Agent(httpsOpts, true)
-      }
 
       // Convert proxy opts to electron API in webtorrent-hybrid
       if (self.tracker.wrtc && self.tracker.wrtc.electronDaemon &&

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function WebTorrent (opts) {
       // Ensure electron-wrtc is used in electron with socks proxy
       if (self.tracker && socksProxy && self.proxyOpts.proxyPeerConnections &&
         process && process.versions['electron'] &&
-        self.tracker.wrtc && !self.tracker.wrtc.electronDaemon) {
+        (!self.tracker.wrtc || (self.tracker.wrtc && !self.tracker.wrtc.electronDaemon))) {
         self.emit('error', 'You need to provide an electron-wrtc instance in opts.wrtc to use Socks proxy in electron -> WebRTC is disabled')
         self.tracker.wrtc = false
       }

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ function WebTorrent (opts) {
       if (self.tracker && socksProxy && self.proxyOpts.proxyPeerConnections &&
         process && process.versions['electron'] &&
         (!self.tracker.wrtc || (self.tracker.wrtc && !self.tracker.wrtc.electronDaemon))) {
-        self.emit('error', 'You need to provide an electron-wrtc instance in opts.wrtc to use Socks proxy in electron -> WebRTC is disabled')
+        console.warn('You need to provide an electron-wrtc instance in opts.wrtc to use Socks proxy in electron -> WebRTC is disabled')
         self.tracker.wrtc = false
       }
 
@@ -139,7 +139,7 @@ function WebTorrent (opts) {
           self.tracker.wrtc.electronDaemon.eval('window.webContents.session.setProxy(' +
                 JSON.stringify(electronConfig) + ', function(){})', networkSettingsReady)
         } else {
-          self.emit('error', 'SOCKS Proxy must be version 5 with no authentication to work in electron-wrtc -> WebRTC is disabled')
+          console.warn('SOCKS Proxy must be version 5 with no authentication to work in electron-wrtc -> WebRTC is disabled')
           self.tracker.wrtc = false
           networkSettingsReady(null)
         }

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var parseTorrent = require('parse-torrent')
 var path = require('path')
 var Peer = require('simple-peer')
 var randombytes = require('randombytes')
+var Socks = require('socks')
 var speedometer = require('speedometer')
 var zeroFill = require('zero-fill')
 
@@ -104,6 +105,26 @@ function WebTorrent (opts) {
       self.tracker.wrtc = opts.wrtc // to support `webtorrent-hybrid` package
     }
     if (global.WRTC && !self.tracker.wrtc) self.tracker.wrtc = global.WRTC
+  }
+
+  // Proxy
+  self.proxyOpts = opts.proxyOpts
+  if (self.proxyOpts) {
+    self.proxyOpts.proxyTrackerConnections = self.proxyOpts.proxyTrackerConnections !== false
+    self.proxyOpts.proxyPeerConnections = self.proxyOpts.proxyPeerConnections !== false
+
+    if (self.proxyOpts.socksProxy) {
+      if (!self.proxyOpts.socksProxy.proxy) self.proxyOpts.socksProxy.proxy = {}
+      if (!self.proxyOpts.socksProxy.proxy.type) self.proxyOpts.socksProxy.proxy.type = 5
+
+      // Create HTTP agents from socks proxy if needed
+      if (!self.proxyOpts.httpAgent) {
+        self.proxyOpts.httpAgent = new Socks.Agent(self.proxyOpts.socksProxy, false)
+      }
+      if (!self.proxyOpts.httpsAgent) {
+        self.proxyOpts.httpsAgent = new Socks.Agent(self.proxyOpts.socksProxy, true)
+      }
+    }
   }
 
   if (typeof TCPPool === 'function') {

--- a/index.js
+++ b/index.js
@@ -116,12 +116,13 @@ function WebTorrent (opts) {
       self.tracker.proxyOpts = self.proxyOpts
     }
 
-    if (self.proxyOpts.socksProxy) {
-      if (!self.proxyOpts.socksProxy.proxy) self.proxyOpts.socksProxy.proxy = {}
-      if (!self.proxyOpts.socksProxy.proxy.type) self.proxyOpts.socksProxy.proxy.type = 5
+    var socksProxy = self.proxyOpts.socksProxy;
+    if (socksProxy) {
+      if (!socksProxy.proxy) socksProxy.proxy = {}
+      if (!socksProxy.proxy.type) socksProxy.proxy.type = 5
 
       // Ensure electron-wrtc is used in electron with socks proxy
-      if (self.proxyOpts.socksProxy && self.proxyOpts.proxyPeerConnections &&
+      if (self.tracker && socksProxy && self.proxyOpts.proxyPeerConnections &&
         process && process.versions['electron'] &&
         self.tracker.wrtc && !self.tracker.wrtc.electronDaemon) {
         self.emit('error', 'You need to provide an electron-wrtc instance in opts.wrtc to use Socks proxy in electron -> WebRTC is disabled')
@@ -129,11 +130,11 @@ function WebTorrent (opts) {
       }
 
       // Convert proxy opts to electron API in webtorrent-hybrid
-      if (self.tracker.wrtc && self.tracker.wrtc.electronDaemon &&
-          self.proxyOpts.socksProxy && self.proxyOpts.proxyPeerConnections) {
-        if (!self.proxyOpts.socksProxy.proxy.authentication && !self.proxyOpts.socksProxy.proxy.userid && self.proxyOpts.socksProxy.proxy.type === 5) {
+      if (self.tracker && self.tracker.wrtc && self.tracker.wrtc.electronDaemon &&
+          socksProxy && self.proxyOpts.proxyPeerConnections) {
+        if (!socksProxy.proxy.authentication && !socksProxy.proxy.userid && socksProxy.proxy.type === 5) {
           var electronConfig = {
-            proxyRules: 'socks' + self.proxyOpts.socksProxy.proxy.type + '://' + self.proxyOpts.socksProxy.proxy.ipAddress + ':' + self.proxyOpts.socksProxy.proxy.port
+            proxyRules: 'socks' + socksProxy.proxy.type + '://' + socksProxy.proxy.ipAddress + ':' + socksProxy.proxy.port
           }
           self.tracker.wrtc.electronDaemon.eval('window.webContents.session.setProxy(' +
                 JSON.stringify(electronConfig) + ', function(){})', networkSettingsReady)

--- a/index.js
+++ b/index.js
@@ -123,10 +123,14 @@ function WebTorrent (opts) {
 
       // Create HTTP agents from socks proxy if needed
       if (!self.proxyOpts.httpAgent) {
-        self.proxyOpts.httpAgent = new Socks.Agent(self.proxyOpts.socksProxy, false)
+        var httpOpts = extend(self.proxyOpts.socksProxy)
+        httpOpts.proxy = extend(opts.proxy)
+        self.proxyOpts.httpAgent = new Socks.Agent(httpOpts, false)
       }
       if (!self.proxyOpts.httpsAgent) {
-        self.proxyOpts.httpsAgent = new Socks.Agent(self.proxyOpts.socksProxy, true)
+        var httpsOpts = extend(self.proxyOpts.socksProxy)
+        httpsOpts.proxy = extend(opts.proxy)
+        self.proxyOpts.httpsAgent = new Socks.Agent(httpsOpts, true)
       }
 
       // Convert proxy opts to electron API in webtorrent-hybrid

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function WebTorrent (opts) {
             proxyRules: 'socks' + socksProxy.proxy.type + '://' + socksProxy.proxy.ipAddress + ':' + socksProxy.proxy.port
           }
           self.tracker.wrtc.electronDaemon.eval('window.webContents.session.setProxy(' +
-                JSON.stringify(electronConfig) + ', function(){})', networkSettingsReady)
+                JSON.stringify(electronConfig) + ', function(){})', {mainProcess: true}, networkSettingsReady)
         } else {
           console.warn('SOCKS Proxy must be version 5 with no authentication to work in electron-wrtc -> WebRTC is disabled')
           self.tracker.wrtc = false

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -26,6 +26,7 @@ var Piece = require('torrent-piece')
 var pump = require('pump')
 var randomIterate = require('random-iterate')
 var sha1 = require('simple-sha1')
+var Socks = require('socks')
 var speedometer = require('speedometer')
 var uniq = require('uniq')
 var utMetadata = require('ut_metadata')
@@ -1658,38 +1659,56 @@ Torrent.prototype._drain = function () {
     port: parts[1]
   }
 
-  var conn = peer.conn = net.connect(opts)
+  if (self.client.proxyOpts && self.client.proxyOpts.socksProxy && self.client.proxyOpts.proxyPeerConnections) {
+    var proxyOpts = extend(self.client.proxyOpts.socksProxy, {
+      command: 'connect',
+      target: opts
+    })
 
-  conn.once('connect', function () { peer.onConnect() })
-  conn.once('error', function (err) { peer.destroy(err) })
-  peer.startConnectTimeout()
+    Socks.createConnection(proxyOpts, onGotSocket)
+  } else {
+    onGotSocket(null, net.connect(opts))
+  }
 
-  // When connection closes, attempt reconnect after timeout (with exponential backoff)
-  conn.on('close', function () {
-    if (self.destroyed) return
+  function onGotSocket (err, socket) {
+    if (err) return peer.destroy(err)
 
-    // TODO: If torrent is done, do not try to reconnect after a timeout
+    var conn = peer.conn = socket
 
-    if (peer.retries >= RECONNECT_WAIT.length) {
-      self._debug(
-        'conn %s closed: will not re-add (max %s attempts)',
-        peer.addr, RECONNECT_WAIT.length
-      )
-      return
+    if (self.client.proxyOpts && self.client.proxyOpts.proxyPeerConnections) {
+      peer.onConnect()
     }
+    conn.once('connect', function () { peer.onConnect() })
+    conn.once('error', function (err) { peer.destroy(err) })
+    peer.startConnectTimeout()
 
-    var ms = RECONNECT_WAIT[peer.retries]
-    self._debug(
-      'conn %s closed: will re-add to queue in %sms (attempt %s)',
-      peer.addr, ms, peer.retries + 1
-    )
+    // When connection closes, attempt reconnect after timeout (with exponential backoff)
+    conn.on('close', function () {
+      if (self.destroyed) return
 
-    var reconnectTimeout = setTimeout(function reconnectTimeout () {
-      var newPeer = self._addPeer(peer.addr)
-      if (newPeer) newPeer.retries = peer.retries + 1
-    }, ms)
-    if (reconnectTimeout.unref) reconnectTimeout.unref()
-  })
+      // TODO: If torrent is done, do not try to reconnect after a timeout
+
+      if (peer.retries >= RECONNECT_WAIT.length) {
+        self._debug(
+            'conn %s closed: will not re-add (max %s attempts)',
+            peer.addr, RECONNECT_WAIT.length
+        )
+        return
+      }
+
+      var ms = RECONNECT_WAIT[peer.retries]
+      self._debug(
+          'conn %s closed: will re-add to queue in %sms (attempt %s)',
+          peer.addr, ms, peer.retries + 1
+      )
+
+      var reconnectTimeout = setTimeout(function reconnectTimeout () {
+        var newPeer = self._addPeer(peer.addr)
+        if (newPeer) newPeer.retries = peer.retries + 1
+      }, ms)
+      if (reconnectTimeout.unref) reconnectTimeout.unref()
+    })
+  }
 }
 
 /**

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1664,7 +1664,6 @@ Torrent.prototype._drain = function () {
       command: 'connect',
       target: opts
     })
-    proxyOpts.proxy = extend(proxyOpts.proxy)
 
     Socks.createConnection(proxyOpts, onGotSocket)
   } else {

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1661,12 +1661,12 @@ Torrent.prototype._drain = function () {
   }
 
   if (self.client.proxyOpts && self.client.proxyOpts.socksProxy && self.client.proxyOpts.proxyPeerConnections) {
-    var proxyOpts = clone(self.client.proxyOpts.socksProxy, {
+    var proxyOpts = extend(self.client.proxyOpts.socksProxy, {
       command: 'connect',
       target: opts
     })
 
-    Socks.createConnection(proxyOpts, onGotSocket)
+    Socks.createConnection(clone(proxyOpts), onGotSocket)
   } else {
     onGotSocket(null, net.connect(opts))
   }

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1664,6 +1664,7 @@ Torrent.prototype._drain = function () {
       command: 'connect',
       target: opts
     })
+    proxyOpts.proxy = extend(proxyOpts.proxy)
 
     Socks.createConnection(proxyOpts, onGotSocket)
   } else {

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -5,6 +5,7 @@ module.exports = Torrent
 var addrToIPPort = require('addr-to-ip-port')
 var BitField = require('bitfield')
 var ChunkStoreWriteStream = require('chunk-store-stream/write')
+var clone = require('clone')
 var debug = require('debug')('webtorrent:torrent')
 var Discovery = require('torrent-discovery')
 var EventEmitter = require('events').EventEmitter
@@ -1660,7 +1661,7 @@ Torrent.prototype._drain = function () {
   }
 
   if (self.client.proxyOpts && self.client.proxyOpts.socksProxy && self.client.proxyOpts.proxyPeerConnections) {
-    var proxyOpts = extend(self.client.proxyOpts.socksProxy, {
+    var proxyOpts = clone(self.client.proxyOpts.socksProxy, {
       command: 'connect',
       target: opts
     })

--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -6,6 +6,7 @@ var debug = require('debug')('webtorrent:webconn')
 var get = require('simple-get')
 var inherits = require('inherits')
 var sha1 = require('simple-sha1')
+var url = require('url')
 var Wire = require('bittorrent-protocol')
 
 var VERSION = require('../package.json').version
@@ -109,20 +110,27 @@ WebConn.prototype.httpRequest = function (pieceIndex, offset, length, cb) {
   }
 
   requests.forEach(function (request) {
-    var url = request.url
+    var parsedUrl = url.parse(request.url)
     var start = request.start
     var end = request.end
     debug(
       'Requesting url=%s pieceIndex=%d offset=%d length=%d start=%d end=%d',
-      url, pieceIndex, offset, length, start, end
+      request.url, pieceIndex, offset, length, start, end
     )
+
+    var agent
+    if (self._torrent.client.proxyOpts && self._torrent.client.proxyOpts.proxyPeerConnections) {
+      agent = parsedUrl.protocol === 'https:'
+        ? self._torrent.client.proxyOpts.httpsAgent : self._torrent.client.proxyOpts.httpAgent
+    }
     var opts = {
-      url: url,
+      url: parsedUrl,
       method: 'GET',
       headers: {
         'user-agent': 'WebTorrent/' + VERSION + ' (https://webtorrent.io)',
         range: 'bytes=' + start + '-' + end
-      }
+      },
+      agent: agent
     }
     get.concat(opts, function (err, res, data) {
       if (hasError) return

--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -2,11 +2,13 @@ module.exports = WebConn
 
 var BitField = require('bitfield')
 var Buffer = require('safe-buffer').Buffer
+var clone = require('clone')
 var debug = require('debug')('webtorrent:webconn')
 var get = require('simple-get')
 var inherits = require('inherits')
 var sha1 = require('simple-sha1')
 var url = require('url')
+var Socks = require('socks')
 var Wire = require('bittorrent-protocol')
 
 var VERSION = require('../package.json').version
@@ -119,9 +121,13 @@ WebConn.prototype.httpRequest = function (pieceIndex, offset, length, cb) {
     )
 
     var agent
-    if (self._torrent.client.proxyOpts && self._torrent.client.proxyOpts.proxyPeerConnections) {
+    var proxyOpts = self._torrent.client.proxyOpts
+    if (proxyOpts && proxyOpts.proxyPeerConnections) {
       agent = parsedUrl.protocol === 'https:'
-        ? self._torrent.client.proxyOpts.httpsAgent : self._torrent.client.proxyOpts.httpAgent
+        ? proxyOpts.httpsAgent : proxyOpts.httpAgent
+      if (!agent && proxyOpts.socksProxy) {
+        agent = new Socks.Agent(clone(proxyOpts.socksProxy), (parsedUrl.protocol === 'https:'))
+      }
     }
     var opts = {
       url: parsedUrl,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bittorrent-dht": "^7.2.2",
     "bittorrent-protocol": "^2.1.5",
     "chunk-store-stream": "^2.0.2",
+    "clone": "^1.0.2",
     "create-torrent": "^3.24.5",
     "debug": "^2.2.0",
     "end-of-stream": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "load-ip-set": false,
     "net": false,
     "os": false,
+    "socks": false,
     "ut_pex": false
   },
   "browserify": {
@@ -56,6 +57,7 @@
     "simple-get": "^2.2.1",
     "simple-peer": "^6.0.4",
     "simple-sha1": "^2.0.8",
+    "socks": "^1.1.9",
     "speedometer": "^1.0.0",
     "stream-to-blob": "^1.0.0",
     "stream-to-blob-url": "^2.1.0",


### PR DESCRIPTION
This PR is based on feross/bittorrent-tracker#157 to proxy tracker connnections and adds proxying on TCP peers and webseeds.

WebRTC peers in webtorrent-hybrid is ok now electron-webrtc has been updated.

Options  are structured like :

```
proxyOpts: {
    socksProxy: {
      proxy: {
        ipAddress: 'localhost',
        port: 1080,
        type: 5
      }
    },
    proxyTrackerConnections: true,
    proxyPeerConnections: false,
    httpAgent: {},
    httpsAgent: {}
}
```

Any thoughts?

Fixes #807
