### PR TITLE
Add IPv6 DHT support

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,6 @@ var zeroFill = require('zero-fill')
 var TCPPool = require('./lib/tcp-pool') // browser exclude
 var Torrent = require('./lib/torrent')
 
-var util = require('util')
-
 /**
  * WebTorrent version.
  */
@@ -122,26 +120,18 @@ function WebTorrent (opts) {
   self._downloadSpeed = speedometer()
   self._uploadSpeed = speedometer()
 
-  debug('Real init!')
-
   // We need one DHT for IPv4, and one DHT for IPv6, as per BEP-0032:
   // "A node wishing to participate in both DHTs must maintain two distinct routing tables, one for IPv4 and one for IPv6."
 
-  var newOpts
-
   if (opts.dht !== false && typeof DHT === 'function' /* browser exclude */) {
-    newOpts = extend({ nodeId: self.nodeId, ipv6: false }, opts.dht)
-    debug('IPv4 dht: ' + util.inspect(opts, false, null))
-    self.dht = new DHT(newOpts)
+    self.dht = new DHT(extend({ nodeId: self.nodeId, ipv6: false }, opts.dht))
     this._initDHT(self.dht)
   } else {
     self.dht = false
   }
 
   if (opts.dht6 !== false && typeof DHT === 'function' /* browser exclude */) {
-    newOpts = extend({ nodeId: self.nodeId, ipv6: true }, opts.dht6)
-    debug('IPv6 dht: ' + util.inspect(opts, false, null))
-    self.dht6 = new DHT(newOpts)
+    self.dht6 = new DHT(extend({ nodeId: self.nodeId, ipv6: true }, opts.dht6))
     this._initDHT(self.dht6)
   } else {
     self.dht6 = false

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -187,6 +187,8 @@ Peer.prototype.onHandshake = function (infoHash, peerId) {
 
 Peer.prototype.handshake = function () {
   var self = this
+
+  debug('SENDING HANDSHAKE: ' + this.addr)
   var opts = {
     dht: self.swarm.private ? false : !!self.swarm.client.dht
   }

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -188,7 +188,6 @@ Peer.prototype.onHandshake = function (infoHash, peerId) {
 Peer.prototype.handshake = function () {
   var self = this
 
-  debug('SENDING HANDSHAKE: ' + this.addr)
   var opts = {
     dht: self.swarm.private ? false : !!self.swarm.client.dht
   }

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -331,6 +331,7 @@ Torrent.prototype._onListening = function () {
     announce: self.announce,
     peerId: self.client.peerId,
     dht: !self.private && self.client.dht,
+    dht6: !self.private && self.client.dht6,
     tracker: trackerOpts,
     port: self.client.torrentPort
   })
@@ -937,7 +938,7 @@ Torrent.prototype._onWire = function (wire, addr) {
   }
 
   // When peer sends PORT message, add that DHT node to routing table
-  if (self.client.dht && self.client.dht.listening) {
+  if ((self.client.dht && self.client.dht.listening) || (self.client.dht6 && self.client.dht6.listening)) {
     wire.on('port', function (port) {
       if (self.destroyed || self.client.dht.destroyed) {
         return
@@ -950,7 +951,12 @@ Torrent.prototype._onWire = function (wire, addr) {
       }
 
       self._debug('port: %s (from %s)', port, addr)
-      self.client.dht.addNode({ host: wire.remoteAddress, port: port })
+
+      if (net.isIPv6(wire.remoteAddress) && self.client.dht6 && self.client.dht6.listening) {
+        self.client.dht6.addNode({ host: wire.remoteAddress, port: port })
+      } else if (net.isIPv4(wire.remoteAddress) && self.client.dht && self.client.dht.listening) {
+        self.client.dht.addNode({ host: wire.remoteAddress, port: port })
+      }
     })
   }
 

--- a/test/browser/basic.js
+++ b/test/browser/basic.js
@@ -21,7 +21,7 @@ if (!(global && global.process && global.process.versions && global.process.vers
   test('image append w/ query selector', function (t) {
     t.plan(6)
 
-    var client = new WebTorrent({ dht: false, tracker: false })
+    var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
     client.on('error', function (err) { t.fail(err) })
     client.on('warning', function (err) { t.fail(err) })
@@ -39,7 +39,7 @@ if (!(global && global.process && global.process.versions && global.process.vers
   test('image append w/ element', function (t) {
     t.plan(6)
 
-    var client = new WebTorrent({ dht: false, tracker: false })
+    var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
     client.on('error', function (err) { t.fail(err) })
     client.on('warning', function (err) { t.fail(err) })
@@ -57,7 +57,7 @@ if (!(global && global.process && global.process.versions && global.process.vers
   test('image render w/ query selector', function (t) {
     t.plan(6)
 
-    var client = new WebTorrent({ dht: false, tracker: false })
+    var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
     client.on('error', function (err) { t.fail(err) })
     client.on('warning', function (err) { t.fail(err) })
@@ -79,7 +79,7 @@ if (!(global && global.process && global.process.versions && global.process.vers
   test('image render w/ element', function (t) {
     t.plan(6)
 
-    var client = new WebTorrent({ dht: false, tracker: false })
+    var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
     client.on('error', function (err) { t.fail(err) })
     client.on('warning', function (err) { t.fail(err) })
@@ -101,7 +101,7 @@ if (!(global && global.process && global.process.versions && global.process.vers
 test('WebTorrent.WEBRTC_SUPPORT', function (t) {
   t.plan(2)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })

--- a/test/client-add-duplicate-trackers.js
+++ b/test/client-add-duplicate-trackers.js
@@ -6,7 +6,7 @@ var WebTorrent = require('../')
 test('client.add: duplicate trackers', function (t) {
   t.plan(3)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -30,7 +30,7 @@ test('client.add: duplicate trackers, with multiple torrents', function (t) {
     announce: [ 'wss://example.com', 'wss://example.com', 'wss://example.com' ]
   }
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -67,7 +67,7 @@ test('client.add: duplicate trackers (including in .torrent file), multiple torr
   var parsedTorrentAlice = extend(fixtures.alice.parsedTorrent)
   parsedTorrentAlice.announce = [ 'wss://example.com', 'wss://example.com', 'wss://example.com' ]
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })

--- a/test/client-add.js
+++ b/test/client-add.js
@@ -7,7 +7,7 @@ var WebTorrent = require('../')
 test('client.add: magnet uri, utf-8 string', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -29,7 +29,7 @@ test('client.add: magnet uri, utf-8 string', function (t) {
 test('client.add: torrent file, buffer', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -51,7 +51,7 @@ test('client.add: torrent file, buffer', function (t) {
 test('client.add: info hash, hex string', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -73,7 +73,7 @@ test('client.add: info hash, hex string', function (t) {
 test('client.add: info hash, buffer', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -95,7 +95,7 @@ test('client.add: info hash, buffer', function (t) {
 test('client.add: parsed torrent, from `parse-torrent`', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -117,7 +117,7 @@ test('client.add: parsed torrent, from `parse-torrent`', function (t) {
 test('client.add: parsed torrent, with string type announce property', function (t) {
   t.plan(7)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -148,7 +148,7 @@ test('client.add: parsed torrent, with string type announce property', function 
 test('client.add: parsed torrent, with array type announce property', function (t) {
   t.plan(7)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -179,7 +179,7 @@ test('client.add: parsed torrent, with array type announce property', function (
 test('client.add: invalid torrent id: empty string', function (t) {
   t.plan(3)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) {
     t.ok(err instanceof Error)
@@ -195,7 +195,7 @@ test('client.add: invalid torrent id: empty string', function (t) {
 test('client.add: invalid torrent id: short buffer', function (t) {
   t.plan(3)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) {
     t.ok(err instanceof Error)

--- a/test/client-destroy.js
+++ b/test/client-destroy.js
@@ -6,7 +6,7 @@ var WebTorrent = require('../')
 test('after client.destroy(), throw on client.add() or client.seed()', function (t) {
   t.plan(3)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -24,7 +24,7 @@ test('after client.destroy(), throw on client.add() or client.seed()', function 
 test('after client.destroy(), no "torrent" or "ready" events emitted', function (t) {
   t.plan(1)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })

--- a/test/client-remove.js
+++ b/test/client-remove.js
@@ -5,7 +5,7 @@ var WebTorrent = require('../')
 test('client.remove: remove by Torrent object', function (t) {
   t.plan(5)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })

--- a/test/client-seed.js
+++ b/test/client-seed.js
@@ -8,7 +8,7 @@ var WebTorrent = require('../')
 test('client.seed: torrent file (Buffer)', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -31,7 +31,7 @@ test('client.seed: torrent file (Buffer)', function (t) {
 test('client.seed: torrent file (Buffer), set name on buffer', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -56,7 +56,7 @@ test('client.seed: torrent file (Blob)', function (t) {
 
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })

--- a/test/duplicate.js
+++ b/test/duplicate.js
@@ -5,7 +5,7 @@ var WebTorrent = require('../')
 test('client.seed followed by duplicate client.add (sync)', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
 
@@ -36,7 +36,7 @@ test('client.seed followed by duplicate client.add (sync)', function (t) {
 test('client.seed followed by duplicate client.add (async)', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
 
@@ -67,7 +67,7 @@ test('client.seed followed by duplicate client.add (async)', function (t) {
 test('client.seed followed by two duplicate client.add calls (sync)', function (t) {
   t.plan(9)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
 
@@ -110,7 +110,7 @@ test('client.seed followed by two duplicate client.add calls (sync)', function (
 test('client.seed followed by two duplicate client.add calls (async)', function (t) {
   t.plan(9)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
 
@@ -153,7 +153,7 @@ test('client.seed followed by two duplicate client.add calls (async)', function 
 test('successive sync client.add, client.remove, client.add, client.remove (sync)', function (t) {
   t.plan(3)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
 

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -6,7 +6,7 @@ var WebTorrent = require('../../')
 test('WebTorrent.WEBRTC_SUPPORT', function (t) {
   t.plan(2)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -29,7 +29,7 @@ test('client.add: http url to a torrent file, string', function (t) {
   server.listen(0, function () {
     var port = server.address().port
     var url = 'http://127.0.0.1:' + port
-    var client = new WebTorrent({ dht: false, tracker: false })
+    var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
     client.on('error', function (err) { t.fail(err) })
     client.on('warning', function (err) { t.fail(err) })
@@ -51,7 +51,7 @@ test('client.add: http url to a torrent file, string', function (t) {
 test('client.add: filesystem path to a torrent file, string', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -71,7 +71,7 @@ test('client.add: filesystem path to a torrent file, string', function (t) {
 test('client.seed: filesystem path to file, string', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -94,7 +94,7 @@ test('client.seed: filesystem path to file, string', function (t) {
 test('client.seed: filesystem path to folder with one file, string', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -114,7 +114,7 @@ test('client.seed: filesystem path to folder with one file, string', function (t
 test('client.seed: filesystem path to folder with multiple files, string', function (t) {
   t.plan(6)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -134,7 +134,7 @@ test('client.seed: filesystem path to folder with multiple files, string', funct
 test('client.add: invalid torrent id: invalid filesystem path', function (t) {
   t.plan(3)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) {
     t.ok(err instanceof Error)

--- a/test/node/blocklist-tracker.js
+++ b/test/node/blocklist-tracker.js
@@ -35,7 +35,7 @@ test('blocklist blocks peers discovered via tracker', function (t) {
     },
 
     function (cb) {
-      client1 = new WebTorrent({ dht: false })
+      client1 = new WebTorrent({ dht: false, dht6: false })
       client1.on('error', function (err) { t.fail(err) })
       client1.on('warning', function (err) { t.fail(err) })
 

--- a/test/node/common.js
+++ b/test/node/common.js
@@ -1,0 +1,34 @@
+var WebTorrent = require('../../')
+
+exports.wrapTest = function (test, str, func) {
+  test('ipv4 ' + str, function (t) {
+    func(t, false)
+    if (t._plan) {
+      t.plan(t._plan + 1)
+    }
+
+    t.test('ipv6 ' + str, function (newT) {
+      func(newT, true)
+    })
+  })
+}
+
+exports.localHost = function (ipv6, plainIpv6) {
+  if (ipv6) {
+    if (!plainIpv6) {
+      return '[::1]'
+    }
+    return '::1'
+  }
+  return '127.0.0.1'
+}
+
+exports.newClient = function (ipv6, port) {
+  var dhtOpts = { bootstrap: this.localHost(ipv6) + ':' + port }
+
+  return new WebTorrent({
+    tracker: false,
+    dht: ipv6 ? false : dhtOpts,
+    dht6: ipv6 ? dhtOpts : false
+  })
+}

--- a/test/node/download-metadata.js
+++ b/test/node/download-metadata.js
@@ -26,7 +26,7 @@ function createServer (data, cb) {
 test('Download metadata for magnet URI with xs parameter', function (t) {
   t.plan(3)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -44,7 +44,7 @@ test('Download metadata for magnet URI with xs parameter', function (t) {
 test('Download metadata for magnet URI with 2 xs parameters', function (t) {
   t.plan(4)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -70,7 +70,7 @@ test('Download metadata for magnet URI with 2 xs parameters', function (t) {
 test('Download metadata for magnet URI with 2 xs parameters, with 1 invalid protocol', function (t) {
   t.plan(3)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -91,7 +91,7 @@ test('Download metadata for magnet URI with 2 xs parameters, with 1 invalid prot
 test('Download metadata for magnet URI with 2 xs parameters, with 1 404 URL', function (t) {
   t.plan(3)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })
@@ -112,7 +112,7 @@ test('Download metadata for magnet URI with 2 xs parameters, with 1 404 URL', fu
 test('Download metadata magnet URI with unsupported protocol in xs parameter', function (t) {
   t.plan(1)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })

--- a/test/node/download-tracker-magnet.js
+++ b/test/node/download-tracker-magnet.js
@@ -47,7 +47,7 @@ function magnetDownloadTest (t, serverType) {
       parsedTorrent.announce = [ announceUrl ]
       magnetURI = 'magnet:?xt=urn:btih:' + parsedTorrent.infoHash + '&tr=' + encodeURIComponent(announceUrl)
 
-      client1 = new WebTorrent({ dht: false })
+      client1 = new WebTorrent({ dht: false, dht6: false })
 
       client1.on('error', function (err) { t.fail(err) })
       client1.on('warning', function (err) { t.fail(err) })
@@ -75,7 +75,7 @@ function magnetDownloadTest (t, serverType) {
     },
 
     function (cb) {
-      client2 = new WebTorrent({ dht: false })
+      client2 = new WebTorrent({ dht: false, dht6: false })
 
       client2.on('error', function (err) { t.fail(err) })
       client2.on('warning', function (err) { t.fail(err) })

--- a/test/node/download-tracker-torrent.js
+++ b/test/node/download-tracker-torrent.js
@@ -40,7 +40,7 @@ function torrentDownloadTest (t, serverType) {
     },
 
     function (cb) {
-      client1 = new WebTorrent({ dht: false })
+      client1 = new WebTorrent({ dht: false, dht6: false })
       client1.on('error', function (err) { t.fail(err) })
       client1.on('warning', function (err) { t.fail(err) })
 
@@ -70,7 +70,7 @@ function torrentDownloadTest (t, serverType) {
     },
 
     function (cb) {
-      client2 = new WebTorrent({ dht: false })
+      client2 = new WebTorrent({ dht: false, dht6: false })
       client2.on('error', function (err) { t.fail(err) })
       client2.on('warning', function (err) { t.fail(err) })
 

--- a/test/node/download-webseed-magnet.js
+++ b/test/node/download-webseed-magnet.js
@@ -26,7 +26,7 @@ test('Download using webseed (via magnet uri)', function (t) {
     },
 
     function (cb) {
-      client1 = new WebTorrent({ dht: false, tracker: false })
+      client1 = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
       client1.on('error', function (err) { t.fail(err) })
       client1.on('warning', function (err) { t.fail(err) })
@@ -61,7 +61,7 @@ test('Download using webseed (via magnet uri)', function (t) {
     },
 
     function (cb) {
-      client2 = new WebTorrent({ dht: false, tracker: false })
+      client2 = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
       client2.on('error', function (err) { t.fail(err) })
       client2.on('warning', function (err) { t.fail(err) })

--- a/test/node/download-webseed-torrent.js
+++ b/test/node/download-webseed-torrent.js
@@ -36,7 +36,7 @@ test('Download using webseed (via .torrent file)', function (t) {
         'http://localhost:' + httpServer.address().port + '/' + fixtures.leaves.parsedTorrent.name
       ]
 
-      client = new WebTorrent({ dht: false, tracker: false })
+      client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
       client.on('error', function (err) { t.fail(err) })
       client.on('warning', function (err) { t.fail(err) })
@@ -97,7 +97,7 @@ test('Disable webseeds', function (t) {
         'http://localhost:' + httpServer.address().port + '/' + fixtures.leaves.parsedTorrent.name
       ]
 
-      client = new WebTorrent({ dht: false, tracker: false, webSeeds: false })
+      client = new WebTorrent({ dht: false, dht6: false, tracker: false, webSeeds: false })
 
       client.on('error', function (err) { t.fail(err) })
       client.on('warning', function (err) { t.fail(err) })

--- a/test/node/extensions.js
+++ b/test/node/extensions.js
@@ -29,12 +29,12 @@ test('extension support', function (t) {
     }
   }
 
-  var client1 = new WebTorrent({ dht: false, tracker: false })
+  var client1 = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client1.on('error', function (err) { t.fail(err) })
   client1.on('warning', function (err) { t.fail(err) })
 
-  var client2 = new WebTorrent({ dht: false, tracker: false })
+  var client2 = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client2.on('error', function (err) { t.fail(err) })
   client2.on('warning', function (err) { t.fail(err) })

--- a/test/node/metadata.js
+++ b/test/node/metadata.js
@@ -5,8 +5,8 @@ var WebTorrent = require('../../')
 test('ut_metadata transfer', function (t) {
   t.plan(6)
 
-  var client1 = new WebTorrent({ dht: false, tracker: false })
-  var client2 = new WebTorrent({ dht: false, tracker: false })
+  var client1 = new WebTorrent({ dht: false, dht6: false, tracker: false })
+  var client2 = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client1.on('error', function (err) { t.fail(err) })
   client1.on('warning', function (err) { t.fail(err) })

--- a/test/node/seed-stream.js
+++ b/test/node/seed-stream.js
@@ -23,7 +23,7 @@ test('client.seed: stream', function (t) {
       var port = tracker.http.address().port
       announceUrl = 'http://localhost:' + port + '/announce'
 
-      seeder = new WebTorrent({ dht: false })
+      seeder = new WebTorrent({ dht: false, dht6: false })
 
       seeder.on('error', function (err) { t.fail(err) })
       seeder.on('warning', function (err) { t.fail(err) })
@@ -45,7 +45,7 @@ test('client.seed: stream', function (t) {
     },
 
     function (cb) {
-      client = new WebTorrent({ dht: false })
+      client = new WebTorrent({ dht: false, dht6: false })
 
       client.on('error', function (err) { t.fail(err) })
       client.on('warning', function (err) { t.fail(err) })

--- a/test/node/server.js
+++ b/test/node/server.js
@@ -7,7 +7,7 @@ var WebTorrent = require('../../')
 test('torrent.createServer: programmatic http server', function (t) {
   t.plan(9)
 
-  var client = new WebTorrent({ tracker: false, dht: false })
+  var client = new WebTorrent({ tracker: false, dht: false, dht6: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })

--- a/test/torrent-destroy.js
+++ b/test/torrent-destroy.js
@@ -5,7 +5,7 @@ var WebTorrent = require('../')
 test('torrent.destroy: destroy and remove torrent', function (t) {
   t.plan(5)
 
-  var client = new WebTorrent({ dht: false, tracker: false })
+  var client = new WebTorrent({ dht: false, dht6: false, tracker: false })
 
   client.on('error', function (err) { t.fail(err) })
   client.on('warning', function (err) { t.fail(err) })


### PR DESCRIPTION
[k-rpc-socket](https://github.com/mafintosh/k-rpc-socket/pull/6) | [k-rpc](https://github.com/mafintosh/k-rpc/pull/5) | [bittorrent-dht](https://github.com/feross/bittorrent-dht/pull/144) | [torrent-discovery](https://github.com/feross/torrent-discovery/pull/27) | webtorrent

This is one of many pull requests across the WebTorrent ecosystem to add IPv6 DHT support, as per https://github.com/feross/bittorrent-dht/issues/88

Per [the BEP 32 statement about maintaining distinct IPv4/IPv6 DHTs](http://www.bittorrent.org/beps/bep_0032.html#operation) and the discussion on https://github.com/feross/bittorrent-dht/issues/88, my implementation requires separate instances of `bittorrent-dht` and everything below it on the protocol stack (`k-rpc` and `k-rpc-socket`). `torrent-discovery` maintains up to two `DHT` instances, one for each IP version used. Fortunately, WebTorrent already supports IPv6 peers, so no changes are needed in it beyond properly using the IPv6 DHT, if enabled in the options.

The best way to run all of my changes is by using the [npm link](https://docs.npmjs.com/cli/link) command. Assuming that all of the necessary modules (`k-rpc-socket`, `k-rpc`, `bittorrent-dht`, `torrent-discovery`, `webtorrent`, and `webtorrent-cli` are sibling directories, the following commands will set things up properly (starting from the parent directory):

```
cd k-rpc-socket
npm install
npm link
cd ../k-rpc
npm install
npm link k-rpc-socket
npm link
cd ../bittorrent-dht
npm install
npm link k-rpc
npm link
cd ../torrent-discovery
npm install
npm link bittorrent-dht
npm link
cd ../webtorrent
npm install
npm link bittorrent-dht
npm link torrent-discovery
npm link
cd ../webtorrent-cli
npm install
npm link webtorrent
```

From there, you can test and run individual modules as you choose.

---

**webtorrent** specific notes:

This PR bring together all of my changes across the other repositories, allowing IPv6 DHT support to actually be used :).

I've added a new `dht6` option, which functions in the same way as the already existent `dht` option does.

Notes:
- The changes needed here were minimal - I store the IPv6 DHT instance in the same way that the IPv4 one is stored, and ensure the PORT messages are handled using the correct protocol. Nearly all of the changes are to tests - for ones which disable DHT, I make sure to disable the IPv6 DHT as well.

Caveats:
- The dht port is always shared between the IPv4 and IPv6 DHT instances. My rationale for this is that the port will usually kept constant between DHT instances - changing the port implies a conceptually separate. However, I can change this if necessary.
- `webtorrent-cli` and `webtorrent-desktop` don't expose any way to selectively enable either the IPv4 DHT or the IPv6 DHT (thought it can be done through the API). However, I don't anticipate this being a very common usecase.
### **Running the implementation**:

No direct changes are needed to `webtorrent-cli` or `webtorrent-desktop` are needed to run this. Since you can't really see any results with `webtorrent-desktop` (neither the peer list nor DHT information is shown), `webtorrent-cli` should be used to test this.

The following steps describe how to best test the IPv6 DHT with `webtorrent-cli`:
1. Ensure that all of the modules are properly linked, as described at the top of the issue.
2. From the `webtorrent-cli` directory, run `DEBUG=torrent-discovery bin/cmd.js download bf6f2be549a8aca5776638b59b2bca53d7bbc748`. (the infohash is for `ubuntu-16.10-server-amd64.iso`) You should see lots of peer message being printed out to the console, many containing IPv6 addresses.

As a side note, you can use only IPv6 peers (both tracker and DHT) by using a blocklist containing this line: [Whole IPV4-Internet:1.1.1.1-224.0.0.0](https://gist.github.com/Aaron1011/0dd772dafc4671fbbbf97f25ab4c084a). This can be enabled with the `--blocklist` flag. With the blocklist saved to `blocklist.txt` in the root of the project, the command would look like this:

`DEBUG=torrent-discovery bin/cmd.js download bf6f2be549a8aca5776638b59b2bca53d7bbc748 --blocklist blocklist.txt`
