### PR TITLE
Add local file deletion on `torrent.destroy`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -167,11 +167,11 @@ Always listen for the 'error' event.
 Remove a torrent from the client. Destroy all connections to peers and delete all saved
 file data. If `callback` is specified, it will be called when file data is removed.
 
-*Note: This method does not currently delete torrent data (in e.g. `/tmp/webtorrent/...`, see the `path` option to `client.add`). Until this is fixed, please implement it yourself (consider using the `rimraf` npm package).
-
 ## `client.destroy([function callback (err) {}])`
 
 Destroy the client, including all torrents and connections to peers. If `callback` is specified, it will be called when the client has gracefully closed.
+
+*Note: Destroying the client does not result in the torrent data suppression. You need to explicitly call `client.remove` or implement it yourself.
 
 ## `client.torrents[...]`
 
@@ -267,6 +267,14 @@ Torrent download location.
 Alias for `client.remove(torrent)`. If `callback` is provided, it will be called when
 the torrent is fully destroyed, i.e. all open sockets are closed, and the storage is
 closed.
+
+## `torrent.delete([callback])`
+
+Does the same as `torrent.destroy([callback])`. If `callback` is provided, it will be
+called when the torrent is fully destroyed, i.e. all open sockets are closed, the
+storage is closed and *torrent data are deleted*.
+
+*Note: Torrent data are only deleted in node applications.
 
 ## `torrent.addPeer(peer)`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -162,10 +162,20 @@ destroyed and all torrents are removed and cleaned up when this occurs.
 
 Always listen for the 'error' event.
 
-## `client.remove(torrentId, [function callback (err) {}])`
+## `client.remove(torrentId, [opts], [function callback (err) {}])`
 
 Remove a torrent from the client. Destroy all connections to peers and delete all saved
-file data. If `callback` is specified, it will be called when file data is removed.
+file data.
+
+If `opts` is specified, then the default options (shown below) will be overridden.
+
+```js
+{
+  remove: Boolean             // Delete torrent data (default to false)
+}
+```
+
+If `callback` is specified, it will be called when file data is removed.
 
 ## `client.destroy([function callback (err) {}])`
 
@@ -262,19 +272,20 @@ Number of peers in the torrent swarm.
 
 Torrent download location.
 
-## `torrent.destroy([callback])`
+## `torrent.destroy([opts], [callback])`
 
-Alias for `client.remove(torrent)`. If `callback` is provided, it will be called when
-the torrent is fully destroyed, i.e. all open sockets are closed, and the storage is
-closed.
+Alias for `client.remove(torrent)`.
 
-## `torrent.delete([callback])`
+If `opts` is specified, then the default options (shown below) will be overridden.
 
-Does the same as `torrent.destroy([callback])`. If `callback` is provided, it will be
-called when the torrent is fully destroyed, i.e. all open sockets are closed, the
-storage is closed and *torrent data are deleted*.
+```js
+{
+  remove: Boolean             // Delete torrent data (default to false)
+}
+```
 
-*Note: Torrent data are only deleted in node applications.
+If `callback` is provided, it will be called when the torrent is fully destroyed, i.e.
+all open sockets are closed, and the storage is closed.
 
 ## `torrent.addPeer(peer)`
 

--- a/index.js
+++ b/index.js
@@ -378,18 +378,20 @@ WebTorrent.prototype.seed = function (input, opts, onseed) {
  * @param  {string|Buffer|Torrent}   torrentId
  * @param  {function} cb
  */
-WebTorrent.prototype.remove = function (torrentId, cb) {
+WebTorrent.prototype.remove = function (torrentId, opts, cb) {
   this._debug('remove')
+  if (typeof opts === 'function') return this.remove(torrentId, null, opts)
   var torrent = this.get(torrentId)
   if (!torrent) throw new Error('No torrent with id ' + torrentId)
-  this._remove(torrentId, cb)
+  this._remove(torrentId, opts, cb)
 }
 
-WebTorrent.prototype._remove = function (torrentId, cb) {
+WebTorrent.prototype._remove = function (torrentId, opts, cb) {
+  if (typeof opts === 'function') return this._remove(torrentId, null, opts)
   var torrent = this.get(torrentId)
   if (!torrent) return
   this.torrents.splice(this.torrents.indexOf(torrent), 1)
-  torrent.delete(cb)
+  torrent.destroy(opts, cb)
 }
 
 WebTorrent.prototype.address = function () {

--- a/index.js
+++ b/index.js
@@ -389,7 +389,7 @@ WebTorrent.prototype._remove = function (torrentId, cb) {
   var torrent = this.get(torrentId)
   if (!torrent) return
   this.torrents.splice(this.torrents.indexOf(torrent), 1)
-  torrent.destroy(cb)
+  torrent.delete(cb)
 }
 
 WebTorrent.prototype.address = function () {

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -638,6 +638,28 @@ Torrent.prototype._onStore = function () {
   self._updateSelections()
 }
 
+Torrent.prototype.delete = function (cb) {
+  var self = this
+  self._delete(cb)
+}
+
+Torrent.prototype._delete = function (cb) {
+  var self = this
+  self.destroy(function (err) {
+    if (err) return cb(err)
+    // We won't delete torrent created from local file
+    // We also can't delete file created on a browser
+    if (typeof window === 'undefined' && !self._fromLocalFile && self.path) {
+      rimraf(self.path, function (err) {
+        if (!cb) return
+        cb(err)
+      })
+    } else {
+      cb()
+    }
+  })
+}
+
 Torrent.prototype.destroy = function (cb) {
   var self = this
   self._destroy(null, cb)
@@ -684,14 +706,6 @@ Torrent.prototype._destroy = function (err, cb) {
   if (self.store) {
     tasks.push(function (cb) {
       self.store.close(cb)
-    })
-  }
-
-  // We won't delete torrent created from local file
-  // We also can't delete file created on a browser
-  if (typeof window === 'undefined' && !self._fromLocalFile && self.path) {
-    tasks.push(function (cb) {
-      rimraf(self.path, cb)
     })
   }
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -25,7 +25,6 @@ var path = require('path')
 var Piece = require('torrent-piece')
 var pump = require('pump')
 var randomIterate = require('random-iterate')
-var rimraf = require('rimraf')
 var sha1 = require('simple-sha1')
 var speedometer = require('speedometer')
 var uniq = require('uniq')
@@ -72,7 +71,6 @@ function Torrent (torrentId, client, opts) {
 
   this.announce = opts.announce
   this.urlList = opts.urlList
-  this._fromLocalFile = opts.path
   this.path = opts.path
   this._store = opts.store || FSChunkStore
   this._getAnnounceOpts = opts.getAnnounceOpts
@@ -638,38 +636,20 @@ Torrent.prototype._onStore = function () {
   self._updateSelections()
 }
 
-Torrent.prototype.delete = function (cb) {
+Torrent.prototype.destroy = function (opts, cb) {
   var self = this
-  self._delete(cb)
+  if (typeof opts === 'function') return self.destroy(null, opts)
+  self._destroy(null, opts, cb)
 }
 
-Torrent.prototype._delete = function (cb) {
+Torrent.prototype._destroy = function (err, opts, cb) {
   var self = this
-  self.destroy(function (err) {
-    if (err) return cb(err)
-    // We won't delete torrent created from local file
-    // We also can't delete file created on a browser
-    if (typeof window === 'undefined' && !self._fromLocalFile && self.path) {
-      rimraf(self.path, function (err) {
-        if (!cb) return
-        cb(err)
-      })
-    } else {
-      cb()
-    }
-  })
-}
-
-Torrent.prototype.destroy = function (cb) {
-  var self = this
-  self._destroy(null, cb)
-}
-
-Torrent.prototype._destroy = function (err, cb) {
-  var self = this
+  if (typeof opts === 'function') return self._destroy(err, null, opts)
   if (self.destroyed) return
   self.destroyed = true
   self._debug('destroy')
+
+  opts = opts ? extend(opts) : {}
 
   self.client._remove(self)
 
@@ -705,7 +685,11 @@ Torrent.prototype._destroy = function (err, cb) {
 
   if (self.store) {
     tasks.push(function (cb) {
-      self.store.close(cb)
+      if (self._store === FSChunkStore && opts.remove) {
+        self.store.destroy(cb)
+      } else {
+        self.store.close(cb)
+      }
     })
   }
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -25,6 +25,7 @@ var path = require('path')
 var Piece = require('torrent-piece')
 var pump = require('pump')
 var randomIterate = require('random-iterate')
+var rimraf = require('rimraf')
 var sha1 = require('simple-sha1')
 var speedometer = require('speedometer')
 var uniq = require('uniq')
@@ -71,7 +72,7 @@ function Torrent (torrentId, client, opts) {
 
   this.announce = opts.announce
   this.urlList = opts.urlList
-
+  this._fromLocalFile = opts.path
   this.path = opts.path
   this._store = opts.store || FSChunkStore
   this._getAnnounceOpts = opts.getAnnounceOpts
@@ -683,6 +684,14 @@ Torrent.prototype._destroy = function (err, cb) {
   if (self.store) {
     tasks.push(function (cb) {
       self.store.close(cb)
+    })
+  }
+
+  // We won't delete torrent created from local file
+  // We also can't delete file created on a browser
+  if (typeof window === 'undefined' && !self._fromLocalFile && self.path) {
+    tasks.push(function (cb) {
+      rimraf(self.path, cb)
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "range-parser": "^1.2.0",
     "readable-stream": "^2.1.4",
     "render-media": "^2.8.0",
+    "rimraf": "^2.6.1",
     "run-parallel": "^1.1.6",
     "run-parallel-limit": "^1.0.3",
     "safe-buffer": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "range-parser": "^1.2.0",
     "readable-stream": "^2.1.4",
     "render-media": "^2.8.0",
-    "rimraf": "^2.6.1",
     "run-parallel": "^1.1.6",
     "run-parallel-limit": "^1.0.3",
     "safe-buffer": "^5.0.1",

--- a/test/torrent-destroy.js
+++ b/test/torrent-destroy.js
@@ -1,8 +1,10 @@
+var fs = require('fs')
+var path = require('path')
 var fixtures = require('webtorrent-fixtures')
 var test = require('tape')
 var WebTorrent = require('../')
 
-test('torrent.destroy: destroy and remove torrent', function (t) {
+test('torrent.destroy: destroy torrent', function (t) {
   t.plan(5)
 
   var client = new WebTorrent({ dht: false, tracker: false })
@@ -17,6 +19,37 @@ test('torrent.destroy: destroy and remove torrent', function (t) {
     t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
 
     torrent.destroy(function (err) { t.error(err, 'torrent destroyed') })
+    t.equal(client.torrents.length, 0)
+
+    client.destroy(function (err) { t.error(err, 'client destroyed') })
+  })
+})
+
+test('torrent.destroy: seed torrent and remove it', function (t) {
+  t.plan(7)
+
+  var client = new WebTorrent({ dht: false, tracker: false })
+
+  client.on('error', function (err) { t.fail(err) })
+  client.on('warning', function (err) { t.fail(err) })
+
+  client.seed(fixtures.leaves.content, {
+    name: 'Leaves of Grass by Walt Whitman.epub',
+    announce: []
+  }, function (torrent) {
+    t.equal(client.torrents.length, 1)
+    t.equal(torrent.infoHash, fixtures.leaves.parsedTorrent.infoHash)
+    t.equal(torrent.magnetURI, fixtures.leaves.magnetURI)
+
+    var completeFileName = path.join(torrent.path, torrent.files[0].name)
+
+    client.remove(torrent, {'remove': true}, function (err) {
+      t.error(err, 'torrent removed')
+      fs.stat(completeFileName, function (err) {
+        if (err && err.code === 'ENOENT') return t.pass('File deleted')
+        t.fail('File not deleted')
+      })
+    })
     t.equal(client.torrents.length, 0)
 
     client.destroy(function (err) { t.error(err, 'client destroyed') })

--- a/test/torrent-destroy.js
+++ b/test/torrent-destroy.js
@@ -45,13 +45,18 @@ test('torrent.destroy: seed torrent and remove it', function (t) {
 
     client.remove(torrent, {'remove': true}, function (err) {
       t.error(err, 'torrent removed')
-      fs.stat(completeFileName, function (err) {
-        if (err && err.code === 'ENOENT') return t.pass('File deleted')
-        t.fail('File not deleted')
-      })
-    })
-    t.equal(client.torrents.length, 0)
+      // Check if stat is available
+      if (fs.stat) {
+        fs.stat(completeFileName, function (err) {
+          if (err && err.code === 'ENOENT') return t.pass('File deleted')
+          t.fail('File not deleted')
+        })
+      } else {
+        t.pass('File deleted')
+      }
+      t.equal(client.torrents.length, 0)
 
-    client.destroy(function (err) { t.error(err, 'client destroyed') })
+      client.destroy(function (err) { t.error(err, 'client destroyed') })
+    })
   })
 })


### PR DESCRIPTION
When we call `torrent.destroy` and we are not running in a browser, we use
`rimraf` to delete the folder containing the torrent files.

This is a work in progress because I need feedback on a good way to implement it.
For instance, `client.destroy` calls `torrent.destroy` on all its torrents, this might be problematic as destroying the client looks like the legitimate way of stopping every torrent transactions but keeping your progress.