### PR TITLE
Only show json-loader requirement for webpack 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,13 @@ to browserify. However, webpack requires the following extra configuration:
   target: 'web',
   node: {
     fs: 'empty'
-  },
+  }
+}
+```
+
+If you are on webpack 1.x, you will also need to add the `json-loader`:
+```js
+{
   module: {
     loaders: [
       // make sure to install the 'json-loader' package: npm install json-loader
@@ -188,6 +194,7 @@ to browserify. However, webpack requires the following extra configuration:
   }
 }
 ```
+
 Otherwise you could also directly use the pre-built version via `require('webtorrent/webtorrent.min')`.
 
 ##### Script tag


### PR DESCRIPTION
json-loader is included in webpack 2 and up: https://webpack.js.org/guides/migrating/#json-loader-is-not-required-anymore