### PR TITLE
Raise error when streaming from a removed torrent

### DIFF
--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -56,6 +56,8 @@ FileStream.prototype._notify = function () {
   if (self._notifying) return
   self._notifying = true
 
+  if (self._torrent.destroyed) return self._destroy(new Error('Torrent removed'))
+
   var p = self._piece
   self._torrent.store.get(p, function (err, buffer) {
     self._notifying = false


### PR DESCRIPTION
In Node.js 8.2.1, when a torrent is removed while a file from it is being
 streamed, file-stream.js exits, crashing Node with a TypeError:

VM535 file-stream.js:64 Uncaught TypeError: Cannot read property 'get' of null

This patch checks whether the torrent has been marked as destroyed, and
 if so, raises the error to the file stream.