### PR TITLE
fix debug function undefined bug

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1647,6 +1647,7 @@ Torrent.prototype.resume = function () {
 }
 
 Torrent.prototype._debug = function () {
+  if (this.destroyed) return
   var args = [].slice.call(arguments)
   args[0] = '[' + this.client._debugId + '] [' + this._debugId + '] ' + args[0]
   debug.apply(null, args)


### PR DESCRIPTION
fix _debug function throw undefined bug when call torrent.destory() function.