### PR TITLE
Updated docs and README to show Safari support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ they can connect to both normal *and* web peers. We hope other clients will foll
 - **No silos.** WebTorrent is a P2P network for the **entire web.** WebTorrent clients
   running on one domain can connect to clients on any other domain.
 - Stream video torrents into a `<video>` tag (`webm (vp8, vp9)` or `mp4 (h.264)`)
-- Supports Chrome, Firefox, and Opera.
+- Supports Chrome, Firefox, Opera and Safari.
 
 <p align="center">
   <a href="https://saucelabs.com/u/webtorrent">

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,7 +3,7 @@
 WebTorrent is a streaming torrent client for **Node.js** and the **web**. WebTorrent
 provides the same API in both environments.
 
-To use WebTorrent in the browser, [WebRTC] support is required (Chrome, Firefox, Opera).
+To use WebTorrent in the browser, [WebRTC] support is required (Chrome, Firefox, Opera, Safari).
 
 [webrtc]: https://en.wikipedia.org/wiki/WebRTC
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -253,7 +253,7 @@ enable next-generation applications in healthcare, education, science, and more.
 WebTorrent is just one example.
 
 WebRTC [works everywhere][webrtc-everywhere], and browser support is excellent.
-**Chrome**, **Firefox**, and **Opera** for Desktop and Android, as well as
+**Chrome**, **Firefox**, **Opera** and **Safari** for Desktop and Android, as well as
 **Microsoft Edge** have support.
 
 You can learn more about WebRTC data channels at [HTML5Rocks][datachannel-intro].

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -253,8 +253,8 @@ enable next-generation applications in healthcare, education, science, and more.
 WebTorrent is just one example.
 
 WebRTC [works everywhere][webrtc-everywhere], and browser support is excellent.
-**Chrome**, **Firefox**, **Opera** and **Safari** for Desktop and Android, as well as
-**Microsoft Edge** have support.
+**Chrome**, **Firefox**, and **Opera** for Desktop and Android, as well as
+**Microsoft Edge** and **Safari** have support.
 
 You can learn more about WebRTC data channels at [HTML5Rocks][datachannel-intro].
 


### PR DESCRIPTION
Safari 11 brings [support for WebRTC](https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Safari_11_0/Safari_11_0.html) allowing webtorrent compatibility. 

I've updated the docs and README to show this as there are a few (now closed) issues wanting Safari support, which is now possible