### PR TITLE
Add hostname option to mitigate DNS rebinding

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -327,6 +327,7 @@ Returns an `http.Server` instance (got from calling `http.createServer`). If
 ```js
 {
   origin: String // Allow requests from specific origin. `false` for same-origin. [default: '*']
+  hostname: String // If specified, only allow requests whose `Host` header matches this hostname. Note that you should not specify the port since this is automatically determined by the server. Ex: `localhost` [default: `undefined`]
 }
 ```
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -51,6 +51,15 @@ function Server (torrent, opts) {
     // deny them
     if (req.headers.origin == null) return false
 
+    // If a 'hostname' string is specified, deny requests with a 'Host'
+    // header that does not match the origin of the torrent server to prevent
+    // DNS rebinding attacks.
+    if (opts.hostname) {
+      if (req.headers.host !== `${opts.hostname}:${server.address().port}`) {
+        return false
+      }
+    }
+
     // The user allowed all origins
     if (opts.origin === '*') return true
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -54,10 +54,8 @@ function Server (torrent, opts) {
     // If a 'hostname' string is specified, deny requests with a 'Host'
     // header that does not match the origin of the torrent server to prevent
     // DNS rebinding attacks.
-    if (opts.hostname) {
-      if (req.headers.host !== `${opts.hostname}:${server.address().port}`) {
-        return false
-      }
+    if (opts.hostname && req.headers.host !== `${opts.hostname}:${server.address().port}`) {
+      return false
     }
 
     // The user allowed all origins


### PR DESCRIPTION
This adds the `hostname` option to allow the server to validate the `Host` header of incoming requests to prevent DNS rebinding attacks. Needed for https://github.com/brave/browser-laptop/issues/12616.

For more context, see https://bugs.chromium.org/p/project-zero/issues/detail?id=1447.