### PR TITLE
Replace zuul with airtap

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -1,4 +1,5 @@
-ui: tape
+sauce_connect: true
+loopback: airtap.local
 browsers:
   - name: chrome
     version: -1..latest

--- a/.airtap.yml
+++ b/.airtap.yml
@@ -2,6 +2,6 @@ sauce_connect: true
 loopback: airtap.local
 browsers:
   - name: chrome
-    version: -1..latest
+    version: latest
   - name: firefox
-    version: -1..latest
+    version: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 'node'
+  - lts/*
 sudo: true
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ env:
   - secure: AJsEWFnWC5W8hcF3hJzm3PT7heazJpKg85xiSvIWVzLHZU/s0h4+WfJ6t0F9v3L4awaowm62vy8CRaxRkB4lJyJg+JK2K0QN7lNFGj2f8Jx2cFlVJ1IyY959GY4iUg66JrNj1yzS02+yQfweDngyifqzb7IlxnowiveDjUO2gyo=
   - secure: hvihwLUqlPchrGFXKWFF7iKRugISU7r/gLBo6O63nPeg0OwnYqYcC2BnBWoSiOdu9oR5bM4a5u0os04XL+bP3dqt324g0uBTqvyyxD6NhBsphVFkUmdUH3HMe7IQY6JTns96KT/6UkQapKhIuW4CUDeidR+5NFKvyRdKIjSawS4=
 
-# For Electron testing on Linux
-# https://github.com/electron/electron/blob/master/docs/tutorial/testing-on-headless-ci.md
 addons:
+  sauce_connect: true
+  hosts:
+    - airtap.local
+  # For Electron testing on Linux
+  # https://github.com/electron/electron/blob/master/docs/tutorial/testing-on-headless-ci.md
   apt:
     packages:
       - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,3 @@ addons:
 before_script:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-cache:
-  directories:
-    - node_modules

--- a/bin/test.js
+++ b/bin/test.js
@@ -6,11 +6,9 @@ var runSauceLabs = !process.env.CI ||
   (process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY)
 
 npmRun('test-node', function () {
-  npmRun('test-browser-headless', function () {
-    if (runSauceLabs) {
-      npmRun('test-browser')
-    }
-  })
+  if (runSauceLabs) {
+    npmRun('test-browser')
+  }
 })
 
 function npmRun (scriptName, onSuccess) {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "build-debug": "browserify -s WebTorrent -e ./ > webtorrent.debug.js",
     "size": "npm run build && cat webtorrent.min.js | gzip | wc -c",
     "test": "standard && node ./bin/test.js",
-    "test-browser-headless": "zuul --electron -- test/*.js test/browser/*.js",
     "test-browser": "airtap -- test/*.js test/browser/*.js",
     "test-browser-local": "airtap --local -- test/*.js test/browser/*.js",
     "test-node": "tape test/*.js test/node/*.js",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "zero-fill": "^2.2.3"
   },
   "devDependencies": {
+    "airtap": "0.0.1",
     "babili": "^0.1.4",
     "bittorrent-tracker": "^9.4.0",
     "brfs": "^1.4.3",
@@ -82,8 +83,7 @@
     "serve-static": "^1.11.1",
     "standard": "*",
     "tape": "^4.6.0",
-    "webtorrent-fixtures": "^1.5.0",
-    "zuul": "^3.10.1"
+    "webtorrent-fixtures": "^1.5.0"
   },
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -116,9 +116,9 @@
     "build-debug": "browserify -s WebTorrent -e ./ > webtorrent.debug.js",
     "size": "npm run build && cat webtorrent.min.js | gzip | wc -c",
     "test": "standard && node ./bin/test.js",
-    "test-browser": "zuul -- test/*.js test/browser/*.js",
     "test-browser-headless": "zuul --electron -- test/*.js test/browser/*.js",
-    "test-browser-local": "zuul --local -- test/*.js test/browser/*.js",
+    "test-browser": "airtap -- test/*.js test/browser/*.js",
+    "test-browser-local": "airtap --local -- test/*.js test/browser/*.js",
     "test-node": "tape test/*.js test/node/*.js",
     "update-authors": "./bin/update-authors.sh"
   }


### PR DESCRIPTION
Testing out a replacement package for zuul called airtap.

https://www.npmjs.com/package/airtap

Much simpler than zuul in that it only supports tap/tape, actively maintained, doesn't rely on the unreliable localtunnel service.

It's still super early software, so I want to test it on a few repos first. Currently added it to these repos:

- `simple-peer`
- `magnet-uri`
- `buffer`
- `webtorrent` (this PR)

It may have big breaking changes before V1, but it's already so much more reliable that I think it's worth it.