### PR TITLE
Fix ratio limit in documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -196,7 +196,7 @@ Total download progress for all **active** torrents, from 0 to 1.
 
 ## `client.ratio`
 
-Aggregate "seed ratio" for all torrents (uploaded / downloaded), from 0 to 1.
+Aggregate "seed ratio" for all torrents (uploaded / downloaded).
 
 
 # Torrent API
@@ -252,7 +252,7 @@ Torrent download progress, from 0 to 1.
 
 ## `torrent.ratio`
 
-Torrent "seed ratio" (uploaded / downloaded), from 0 to 1.
+Torrent "seed ratio" (uploaded / downloaded).
 
 ## `torrent.numPeers`
 


### PR DESCRIPTION
The value of ratio isn't limited to 0-1, which can be checked [here](https://github.com/webtorrent/webtorrent/blob/b53d224cdea46173ea97dc9eea7eaf5a6e7a55b9/lib/torrent.js#L177-L179) and [here](https://github.com/webtorrent/webtorrent/blob/b53d224cdea46173ea97dc9eea7eaf5a6e7a55b9/index.js#L195-L205). It probably was a mistake caused by copy-pasting the documentation of "progress", which is limited to 0-1. The commit where this extra info was added [is this one](https://github.com/webtorrent/webtorrent/commit/6f2e85cd4649b3f1ddd67be9f4832c0138849b3e).

As this value is the result of something like `uploaded / max(1, downloaded)` it never get's to `Infinity`, so it's limited by 0 and `uploaded`. Without the ` || 1` part it would be limited between 0 and infinity.

