### PR TITLE
Defer Store Verification

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -100,6 +100,8 @@ function Torrent (torrentId, client, opts) {
   this._amInterested = false
   this._selections = []
   this._critical = []
+  this._verified = []
+  this._verifying = []
 
   this.wires = [] // open wires (added *after* handshake)
 
@@ -548,7 +550,6 @@ Torrent.prototype._onMetadata = function (metadata) {
         for (var index = 0; index < self.pieces.length; index++) {
           self._markVerified(index)
         }
-        self._onStore()
       } else {
         self._verifyPieces()
       }
@@ -558,6 +559,7 @@ Torrent.prototype._onMetadata = function (metadata) {
   }
 
   self.emit('metadata')
+  self._onStore()
 }
 
 /*
@@ -586,30 +588,64 @@ Torrent.prototype._verifyPieces = function () {
   var self = this
   parallelLimit(self.pieces.map(function (_, index) {
     return function (cb) {
-      if (self.destroyed) return cb(new Error('torrent is destroyed'))
-
-      self.store.get(index, function (err, buf) {
-        if (self.destroyed) return cb(new Error('torrent is destroyed'))
-
-        if (err) return process.nextTick(cb, null) // ignore error
-        sha1(buf, function (hash) {
-          if (self.destroyed) return cb(new Error('torrent is destroyed'))
-
-          if (hash === self._hashes[index]) {
-            if (!self.pieces[index]) return
-            self._debug('piece verified %s', index)
-            self._markVerified(index)
-          } else {
-            self._debug('piece invalid %s', index)
-          }
-          cb(null)
-        })
-      })
+      self._verify(index, cb)
     }
   }), FILESYSTEM_CONCURRENCY, function (err) {
     if (err) return self._destroy(err)
     self._debug('done verifying')
-    self._onStore()
+  })
+}
+
+Torrent.prototype._verify = function (index, cb) {
+  var self = this
+
+  if (self.destroyed) return cb(new Error('torrent is destroyed'))
+  if (self._verifying[index] || self.bitfield.get(index) || self._verified[index]) {
+    // call cb() asynchronously so that parallelLimit() won't block
+    return process.nextTick(cb, null)
+  }
+
+  self._verifying[index] = true
+
+  self.store.get(index, function (err, buf) {
+    if (self.destroyed) return cb(new Error('torrent is destroyed'))
+    // a critical piece might have been downloaded before this callback
+    if (self.bitfield.get(index)) return cb(null)
+
+    if (err) {
+      // interpret any error as not having the chunk
+      self._verified[index] = true
+      self._update()
+      return cb(null)
+    }
+
+    sha1(buf, function (hash) {
+      if (self.destroyed) return cb(new Error('torrent is destroyed'))
+      // a critical piece might have been downloaded before this callback
+      if (self.bitfield.get(index)) return cb(null)
+
+      if (hash === self._hashes[index]) {
+        self._debug('piece verified %s', index)
+        self._markVerified(index)
+
+        self.wires.forEach(function (wire) {
+          wire.have(index)
+        })
+
+        // We also check `self.destroyed` since `torrent.destroy()` could have been
+        // called in the `torrent.on('done')` handler, triggered by `_checkDone()`.
+        if (self._checkDone() && !self.destroyed) self.discovery.complete()
+
+        self._update()
+
+        cb(null)
+      } else {
+        self._debug('piece invalid %s', index)
+        self._verified[index] = true
+        self._update()
+        cb(null)
+      }
+    })
   })
 }
 
@@ -1470,6 +1506,16 @@ Torrent.prototype._request = function (wire, index, hotswap) {
 
   if (self.bitfield.get(index)) return false
 
+  if (!self._verified[index]) {
+    if (self._critical[index]) {
+      // if the piece is critical then start its verification immediately
+      self._verify(index, noop)
+    } else {
+      // cancel the request unless the piece is critical
+      return false
+    }
+  }
+
   var maxOutstandingRequests = isWebSeed
     ? Math.min(
       getPiecePipelineLength(wire, PIPELINE_MAX_DURATION, self.pieceLength),
@@ -1498,7 +1544,8 @@ Torrent.prototype._request = function (wire, index, hotswap) {
   var chunkLength = isWebSeed ? piece.chunkLengthRemaining(reservation) : piece.chunkLength(reservation)
 
   wire.request(index, chunkOffset, chunkLength, function onChunk (err, chunk) {
-    if (self.destroyed) return
+    // A critical piece may have been verified as in the store before the callback
+    if (self.destroyed || self.bitfield.get(index)) return
 
     // TODO: what is this for?
     if (!self.ready) return self.once('ready', function () { onChunk(err, chunk) })

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -630,7 +630,7 @@ Torrent.prototype._verify = function (index, cb) {
       if (self.bitfield.get(index)) return cb(null)
 
       if (hash === self._hashes[index]) {
-        self._debug('piece verified %s', index)
+        self._debug('piece from store verified %s', index)
         self._markInStore(index)
 
         self.wires.forEach(function (wire) {
@@ -645,7 +645,7 @@ Torrent.prototype._verify = function (index, cb) {
 
         cb(null)
       } else {
-        self._debug('piece invalid %s', index)
+        self._debug('piece from store invalid %s', index)
         self._verified[index] = true
         self._update()
         cb(null)
@@ -1568,7 +1568,7 @@ Torrent.prototype._request = function (wire, index, hotswap) {
 
       if (hash === self._hashes[index]) {
         if (!self.pieces[index]) return
-        self._debug('piece verified %s', index)
+        self._debug('piece from wire verified %s', index)
 
         self.pieces[index] = null
         self._reservations[index] = null
@@ -1585,7 +1585,7 @@ Torrent.prototype._request = function (wire, index, hotswap) {
         if (self._checkDone() && !self.destroyed) self.discovery.complete()
       } else {
         self.pieces[index] = new Piece(piece.length)
-        self.emit('warning', new Error('Piece ' + index + ' failed verification'))
+        self.emit('warning', new Error('Piece from wire ' + index + ' failed verification'))
       }
       onUpdateTick()
     })

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -605,7 +605,7 @@ Torrent.prototype._verify = function (index, cb) {
   var self = this
 
   if (self.destroyed) return cb(new Error('torrent is destroyed'))
-  if (self._verifying[index] || self.bitfield.get(index) || self._verified[index]) {
+  if (self._verifying[index] || self._verified[index]) {
     // call cb() asynchronously so that parallelLimit() won't block
     return process.nextTick(cb, null)
   }
@@ -614,8 +614,6 @@ Torrent.prototype._verify = function (index, cb) {
 
   self.store.get(index, function (err, buf) {
     if (self.destroyed) return cb(new Error('torrent is destroyed'))
-    // a critical piece might have been downloaded before this callback
-    if (self.bitfield.get(index)) return cb(null)
 
     if (err) {
       // interpret any error as not having the chunk
@@ -626,8 +624,6 @@ Torrent.prototype._verify = function (index, cb) {
 
     sha1(buf, function (hash) {
       if (self.destroyed) return cb(new Error('torrent is destroyed'))
-      // a critical piece might have been downloaded before this callback
-      if (self.bitfield.get(index)) return cb(null)
 
       if (hash === self._hashes[index]) {
         self._debug('piece from store verified %s', index)
@@ -1494,13 +1490,10 @@ Torrent.prototype._request = function (wire, index, hotswap) {
   if (self.bitfield.get(index)) return false
 
   if (!self._verified[index]) {
-    if (self._critical[index]) {
-      // if the piece is critical then start its verification immediately
-      self._verify(index, noop)
-    } else {
-      // cancel the request unless the piece is critical
-      return false
-    }
+    // verify critical pieces as soon as possible
+    if (self._critical[index]) self._verify(index, noop)
+
+    return false
   }
 
   var maxOutstandingRequests = isWebSeed
@@ -1531,11 +1524,7 @@ Torrent.prototype._request = function (wire, index, hotswap) {
   var chunkLength = isWebSeed ? piece.chunkLengthRemaining(reservation) : piece.chunkLength(reservation)
 
   wire.request(index, chunkOffset, chunkLength, function onChunk (err, chunk) {
-    // A critical piece may have been verified as in the store before the callback
-    if (self.destroyed || self.bitfield.get(index)) return
-
-    // TODO: what is this for?
-    if (!self.ready) return self.once('ready', function () { onChunk(err, chunk) })
+    if (self.destroyed) return
 
     if (r[i] === wire) r[i] = null
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -534,6 +534,8 @@ Torrent.prototype._onMetadata = function (metadata) {
     self._onWireWithMetadata(wire)
   })
 
+  self.emit('metadata')
+
   self._debug('verifying existing torrent data')
   if (self._fileModtimes && self._store === FSChunkStore) {
     // don't verify if the files haven't been modified since we last checked
@@ -550,6 +552,9 @@ Torrent.prototype._onMetadata = function (metadata) {
         for (var index = 0; index < self.pieces.length; index++) {
           self._markInStore(index)
         }
+        self._checkDone()
+
+        self.updateSelections()
       } else {
         self._verifyPieces()
       }
@@ -558,8 +563,8 @@ Torrent.prototype._onMetadata = function (metadata) {
     self._verifyPieces()
   }
 
-  self.emit('metadata')
-  self._onStore()
+  self.ready = true
+  self.emit('ready')
 }
 
 /*
@@ -653,24 +658,6 @@ Torrent.prototype._markInStore = function (index) {
   this.pieces[index] = null
   this._reservations[index] = null
   this.bitfield.set(index, true)
-}
-
-/**
- * Called when the metadata, listening server, and underlying chunk store is initialized.
- */
-Torrent.prototype._onStore = function () {
-  var self = this
-  if (self.destroyed) return
-  self._debug('on store')
-
-  self.ready = true
-  self.emit('ready')
-
-  // Files may start out done if the file was already in the store
-  self._checkDone()
-
-  // In case any selections were made before torrent was ready
-  self._updateSelections()
 }
 
 Torrent.prototype.destroy = function (cb) {

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -548,7 +548,7 @@ Torrent.prototype._onMetadata = function (metadata) {
 
       if (unchanged) {
         for (var index = 0; index < self.pieces.length; index++) {
-          self._markVerified(index)
+          self._markInStore(index)
         }
       } else {
         self._verifyPieces()
@@ -626,7 +626,7 @@ Torrent.prototype._verify = function (index, cb) {
 
       if (hash === self._hashes[index]) {
         self._debug('piece verified %s', index)
-        self._markVerified(index)
+        self._markInStore(index)
 
         self.wires.forEach(function (wire) {
           wire.have(index)
@@ -649,7 +649,7 @@ Torrent.prototype._verify = function (index, cb) {
   })
 }
 
-Torrent.prototype._markVerified = function (index) {
+Torrent.prototype._markInStore = function (index) {
   this.pieces[index] = null
   this._reservations[index] = null
   this.bitfield.set(index, true)


### PR DESCRIPTION
This PR is to fix the problem demonstrated here: https://jsfiddle.net/1g80d0aj/18/
The entire store needs to be verified before any files in the torrent can be accessed or streamed. This leads to a massive delay in appending the video when using a store with a significant read time instead of the default in-memory store. ([this is the indexeddb chunk store used in the demo](https://github.com/xuset/indexeddb-chunk-store)).

To fix this, I made the 'ready' event fire before store verification finishes, and any calls to _request() are cancelled if that piece hasn't yet been checked for in the store.

Critical pieces are verified immediately instead of being waited for in the parallelLimit() queue, ~~and requests for critical pieces aren't cancelled before verification like normal pieces~~. This allows file streams to work as quickly as possible.

(EDIT: Critical pieces are now also cancelled before verification)

Here's the same demo but using a minified build from this PR instead of the latest webtorrent build. https://jsfiddle.net/6r2hgxf5/11/

&nbsp;

Viewing this one commit at a time might make the changes clearer.