### PR TITLE
Option to destroy store on torrent removal (delete files from disk)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -163,12 +163,14 @@ destroyed and all torrents are removed and cleaned up when this occurs.
 
 Always listen for the 'error' event.
 
-## `client.remove(torrentId, [function callback (err) {}])`
+## `client.remove(torrentId, [opts], [function callback (err) {}])`
 
-Remove a torrent from the client. Destroy all connections to peers and delete all saved
-file data. If `callback` is specified, it will be called when file data is removed.
+Remove a torrent from the client. Destroy all connections to peers and delete all saved file metadata.
 
-*Note: This method does not currently delete torrent data (in e.g. `/tmp/webtorrent/...`, see the `path` option to `client.add`). Until this is fixed, please implement it yourself (consider using the `rimraf` npm package).
+If `opts.destroyStore` is truthy, `store.destroy()` will be called, which will delete the torrent's files from the disk.
+
+If `callback` is provided, it will be called when the torrent is fully destroyed,
+i.e. all open sockets are closed, and the storage is either closed or destroyed.
 
 ## `client.destroy([function callback (err) {}])`
 
@@ -319,11 +321,14 @@ Author of the torrent (string).
 
 A comment optionnaly set by the author (string).
 
-## `torrent.destroy([callback])`
+## `torrent.destroy([opts], [callback])`
 
-Alias for `client.remove(torrent)`. If `callback` is provided, it will be called when
-the torrent is fully destroyed, i.e. all open sockets are closed, and the storage is
-closed.
+Remove the torrent from its client. Destroy all connections to peers and delete all saved file metadata.
+
+If `opts.destroyStore` is truthy, `store.destroy()` will be called, which will delete the torrent's files from the disk.
+
+If `callback` is provided, it will be called when the torrent is fully destroyed,
+i.e. all open sockets are closed, and the storage is either closed or destroyed.
 
 ## `torrent.addPeer(peer)`
 

--- a/index.js
+++ b/index.js
@@ -334,18 +334,22 @@ class WebTorrent extends EventEmitter {
    * @param  {string|Buffer|Torrent}   torrentId
    * @param  {function} cb
    */
-  remove (torrentId, cb) {
+  remove (torrentId, opts, cb) {
+    if (typeof opts === 'function') return this.remove(torrentId, null, opts)
+
     this._debug('remove')
     const torrent = this.get(torrentId)
     if (!torrent) throw new Error(`No torrent with id ${torrentId}`)
-    this._remove(torrentId, cb)
+    this._remove(torrentId, opts, cb)
   }
 
-  _remove (torrentId, cb) {
+  _remove (torrentId, opts, cb) {
+    if (typeof opts === 'function') return this._remove(torrentId, null, opts)
+
     const torrent = this.get(torrentId)
     if (!torrent) return
     this.torrents.splice(this.torrents.indexOf(torrent), 1)
-    torrent.destroy(cb)
+    torrent.destroy(opts, cb)
   }
 
   address () {

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -641,11 +641,14 @@ class Torrent extends EventEmitter {
     this._updateSelections()
   }
 
-  destroy (cb) {
-    this._destroy(null, cb)
+  destroy (opts, cb) {
+    if (typeof opts === 'function') return this.destroy(null, opts)
+
+    this._destroy(null, opts, cb)
   }
 
-  _destroy (err, cb) {
+  _destroy (err, opts, cb) {
+    if (typeof opts === 'function') return this._destroy(err, null, opts)
     if (this.destroyed) return
     this.destroyed = true
     this._debug('destroy')
@@ -682,7 +685,11 @@ class Torrent extends EventEmitter {
 
     if (this.store) {
       tasks.push(cb => {
-        this.store.close(cb)
+        if (opts && opts.destroyStore) {
+          this.store.destroy(cb)
+        } else {
+          this.store.close(cb)
+        }
       })
     }
 


### PR DESCRIPTION
Intended to replace https://github.com/webtorrent/webtorrent/pull/1102

Should work with custom stores like indexeddb as well, but I didn't test that.

API is this:

``` javascript
client.remove(torrentId, {destroyStore: true}, () => console.log('files deleted'))

torrent.destroy({destroyStore: true}, () => console.log('files deleted'))
```

fixes https://github.com/webtorrent/webtorrent/issues/1000