### PR TITLE
fix EventEmitter memory leak

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1500,9 +1500,6 @@ Torrent.prototype._request = function (wire, index, hotswap) {
   wire.request(index, chunkOffset, chunkLength, function onChunk (err, chunk) {
     if (self.destroyed) return
 
-    // TODO: what is this for?
-    if (!self.ready) return self.once('ready', function () { onChunk(err, chunk) })
-
     if (r[i] === wire) r[i] = null
 
     if (piece !== self.pieces[index]) return onUpdateTick()


### PR DESCRIPTION
On some torrents, after resuming, `webtorrent-cli` throw this warning:
```
(node:13649) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 ready listeners added. Use emitter.setMaxListeners() to increase limit
    at _addListener (events.js:188:19)
    at Torrent.addListener (events.js:205:10)
    at Torrent.once (events.js:236:8)
    at Request.onChunk [as callback] (/home/bricewge/tmp/webtorrent-cli/node_modules/webtorrent/lib/torrent.js:1504:34)
    at Wire._callback (/home/bricewge/tmp/webtorrent-cli/node_modules/bittorrent-protocol/index.js:608:11)
    at Wire._onPiece (/home/bricewge/tmp/webtorrent-cli/node_modules/bittorrent-protocol/index.js:512:8)
    at Wire._onMessage (/home/bricewge/tmp/webtorrent-cli/node_modules/bittorrent-protocol/index.js:678:19)
    at Wire._write (/home/bricewge/tmp/webtorrent-cli/node_modules/bittorrent-protocol/index.js:596:10)
    at doWrite (/home/bricewge/tmp/webtorrent-cli/node_modules/readable-stream/lib/_stream_writable.js:428:64)
    at writeOrBuffer (/home/bricewge/tmp/webtorrent-cli/node_modules/readable-stream/lib/_stream_writable.js:417:5)
```
This PR seems to fix that.

It's related to #1122 and webtorrent/webtorrent-cli/issues/55.