### PR TITLE
ProBot: Disable the lock comment

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,6 +1,4 @@
 # ProBot Lock Threads (https://probot.github.io/apps/lock/)
 
 daysUntilLock: 365
-lockComment: >
-  This thread has been automatically locked because it has not had recent
-  activity. To discuss futher, please open a new issue.
+lockComment: false


### PR DESCRIPTION
Sorry for all the spam! Let's disable the comment when the bot locks the issue. It's not really necessary to notify all repo watchers whenever an issue is locked (even once it finishes locking all old issues and the flood slows down)