### PR TITLE
Access-Control-Allow-Methods should be GET,HEAD

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -111,7 +111,7 @@ function Server (torrent, opts) {
     function serveOptionsRequest () {
       res.statusCode = 204 // no content
       res.setHeader('Access-Control-Max-Age', '600')
-      res.setHeader('Access-Control-Allow-Methods', 'GET,HEAD,PUT,PATCH,POST,DELETE')
+      res.setHeader('Access-Control-Allow-Methods', 'GET,HEAD')
 
       if (req.headers['access-control-request-headers']) {
         res.setHeader(


### PR DESCRIPTION
Fixes: https://github.com/webtorrent/webtorrent/issues/1267