### PR TITLE
Implements BEP53 to allow file selection using &so in magnetURIs

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -30,6 +30,7 @@ var speedometer = require('speedometer')
 var uniq = require('uniq')
 var utMetadata = require('ut_metadata')
 var utPex = require('ut_pex') // browser exclude
+var parseRange = require('parse-numeric-range')
 
 var File = require('./file')
 var Peer = require('./peer')
@@ -482,11 +483,6 @@ Torrent.prototype._onMetadata = function (metadata) {
     })
   }
 
-  // start off selecting the entire torrent with low priority
-  if (self.pieces.length !== 0) {
-    self.select(0, self.pieces.length - 1, false)
-  }
-
   self._rarityMap = new RarityMap(self)
 
   self.store = new ImmediateChunkStore(
@@ -508,6 +504,22 @@ Torrent.prototype._onMetadata = function (metadata) {
   self.files = self.files.map(function (file) {
     return new File(self, file)
   })
+
+  // Only select specified files (BEP53)
+  if (self.so) {
+    var specificFiles = parseRange.parse(self.so)
+    // https://github.com/webtorrent/webtorrent/issues/164
+    self.deselect(0, self.pieces.length - 1, false)
+
+    self.files.forEach(function (v, i) {
+      specificFiles.indexOf(i) === -1 ? self.files[i].deselect() : self.files[i].select(true)
+    })
+  } else {
+    // start off selecting the entire torrent with low priority
+    if (self.pieces.length !== 0) {
+      self.select(0, self.pieces.length - 1, false)
+    }
+  }
 
   self._hashes = self.pieces
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -505,14 +505,12 @@ Torrent.prototype._onMetadata = function (metadata) {
     return new File(self, file)
   })
 
-  // Only select specified files (BEP53)
+  // Select only specified files (BEP53) http://www.bittorrent.org/beps/bep_0053.html
   if (self.so) {
-    var specificFiles = parseRange.parse(self.so)
-    // https://github.com/webtorrent/webtorrent/issues/164
-    self.deselect(0, self.pieces.length - 1, false)
+    var selectOnlyFiles = parseRange.parse(self.so)
 
     self.files.forEach(function (v, i) {
-      specificFiles.indexOf(i) === -1 ? self.files[i].deselect() : self.files[i].select(true)
+      if (selectOnlyFiles.includes(i)) self.files[i].select(true)
     })
   } else {
     // start off selecting the entire torrent with low priority

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "mime": "^2.2.0",
     "multistream": "^2.0.5",
     "package-json-versionify": "^1.0.2",
+    "parse-numeric-range": "^0.0.2",
     "parse-torrent": "^6.0.0",
     "pump": "^3.0.0",
     "random-iterate": "^1.0.1",


### PR DESCRIPTION
This pull request implements [BEP53](http://www.bittorrent.org/beps/bep_0053.html) as requested in #1395.

If `&so=` is specified, all pieces are deselected and only the pieces which contain parts of the selected files are downloaded, if no pieces are specified, the entire file is left deselected.

The use of [parse-numeric-range](https://www.npmjs.com/package/parse-numeric-range) allows for ranges to be specified in three different formats which include using hyphens, which is what the BEP calls for, e.g. `1-5` which is equal to `[1, 2, 3, 4, 5]`, using two dots e.g. `1..5` which is also equal to `[1, 2, 3, 4, 5]` or by using three dots e.g. `1...5` which would equal `[1, 2, 3, 4]`.

Any feedback or suggestions are welcome.