### PR TITLE
Persist DHT nodes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -58,7 +58,8 @@ If `opts` is specified, then the default options (shown below) will be overridde
   peerId: String|Buffer,    // Wire protocol peer ID (default=randomly generated)
   tracker: Boolean|Object,  // Enable trackers (default=true), or options object for Tracker
   dht: Boolean|Object,      // Enable DHT (default=true), or options object for DHT
-  dhtState: Boolean|String, // Persist DHT nodes (default=true), or save file path
+  persistDht: Boolean,      // Persist DHT nodes (default=true)
+  persistDhtPath: String,   // DHT persist save file (default=dht.json under OS appdata dir)
   webSeeds: Boolean         // Enable BEP19 web seeds (default=true)
 }
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,12 +53,13 @@ If `opts` is specified, then the default options (shown below) will be overridde
 
 ```js
 {
-  maxConns: Number,        // Max number of connections per torrent (default=55)
-  nodeId: String|Buffer,   // DHT protocol node ID (default=randomly generated)
-  peerId: String|Buffer,   // Wire protocol peer ID (default=randomly generated)
-  tracker: Boolean|Object, // Enable trackers (default=true), or options object for Tracker
-  dht: Boolean|Object,     // Enable DHT (default=true), or options object for DHT
-  webSeeds: Boolean        // Enable BEP19 web seeds (default=true)
+  maxConns: Number,         // Max number of connections per torrent (default=55)
+  nodeId: String|Buffer,    // DHT protocol node ID (default=randomly generated)
+  peerId: String|Buffer,    // Wire protocol peer ID (default=randomly generated)
+  tracker: Boolean|Object,  // Enable trackers (default=true), or options object for Tracker
+  dht: Boolean|Object,      // Enable DHT (default=true), or options object for DHT
+  dhtState: Boolean|String, // Persist DHT nodes (default=true), or save file path
+  webSeeds: Boolean         // Enable BEP19 web seeds (default=true)
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -140,7 +140,14 @@ function WebTorrent (opts) {
       if (!('bootstrap' in dhtOpts)) {
         // Load persisted state
         var nodes = dhtPersist.loadNodes(self.dhtSaveFile)
-        if (nodes) dhtOpts.bootstrap = nodes
+        if (nodes) {
+          var bootstrap = []
+          for (var node of nodes) {
+            var nodeString = node.host + ':' + node.port
+            bootstrap.push(nodeString)
+          }
+          dhtOpts.bootstrap = bootstrap
+        }
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function WebTorrent (opts) {
           ? path.join(appDataFolder('webtorrent'), 'dht.json')
           : opts.dhtState
 
-      if (!('bootstrap' in dhtOpts)) {
+      if (!dhtOpts.bootstrap) {
         // Load persisted state
         var nodes = dhtPersist.loadNodes(self.dhtSaveFile)
         if (nodes) {

--- a/index.js
+++ b/index.js
@@ -80,8 +80,8 @@ function WebTorrent (opts) {
   }
   self.nodeIdBuffer = Buffer.from(self.nodeId, 'hex')
 
-  // Default opts.dhtState to true
-  if (!('dhtState' in opts)) opts.dhtState = true
+  // Default DHT persistence flag
+  if (!('persistDht' in opts)) opts.persistDht = true
 
   self._debugId = self.peerId.toString('hex').substring(0, 7)
 
@@ -130,12 +130,11 @@ function WebTorrent (opts) {
   if (opts.dht !== false && typeof DHT === 'function' /* browser exclude */) {
     var dhtOpts = extend({ nodeId: self.nodeId }, opts.dht)
 
-    if (opts.dhtState) {
+    if (opts.persistDht) {
       // Construct state save location
       self.dhtSaveFile =
-        opts.dhtState === true
-          ? path.join(appDataFolder('webtorrent'), 'dht.json')
-          : opts.dhtState
+        opts.persistDhtPath ||
+        path.join(appDataFolder('webtorrent'), 'dht.json')
 
       if (!dhtOpts.bootstrap) {
         // Load persisted state
@@ -154,7 +153,7 @@ function WebTorrent (opts) {
     // use a single DHT instance for all torrents, so the routing table can be reused
     self.dht = new DHT(dhtOpts)
 
-    if (opts.dhtState) {
+    if (opts.persistDht) {
       // Persist state periodically
       var saveInterval = 15 * 60 * 1000 // 15 minutes
       self.saveDhtStateTimer = setInterval(function saveDhtState () {

--- a/lib/dhtpersist.js
+++ b/lib/dhtpersist.js
@@ -1,0 +1,78 @@
+var fs = require('fs')
+var mkdirp = require('mkdirp')
+var path = require('path')
+
+var savingDhtState = false
+function saveDhtState (dht, file, cb) {
+  if (savingDhtState) return
+  if (!dht) return // Quell after destroy
+  savingDhtState = true
+  var dhtState = dht.toJSON()
+  var dhtStateJson = JSON.stringify(dhtState)
+  mkdirp(
+    path.dirname(file),
+    function handleDhtSaveDirCreated (err) {
+      if (err) {
+        savingDhtState = false
+        if (cb) cb(err)
+        return
+      }
+      fs.writeFile(
+        file,
+        dhtStateJson,
+        function handleDhtStateWritten () {
+          savingDhtState = false
+          if (cb) cb(null)
+        }
+      )
+    }
+  )
+}
+
+function readDhtState (file) {
+  try {
+    return fs.readFileSync(file)
+  } catch (e) {
+    switch (e.code) {
+      case 'EACCES':
+      case 'EISDIR':
+      case 'ENOENT':
+      case 'EPERM':
+        return null
+      default:
+        throw e
+    }
+  }
+}
+
+function parseDhtState (dhtStateJson) {
+  try {
+    return JSON.parse(dhtStateJson)
+  } catch (e) {
+    if (e instanceof SyntaxError) return null
+    else throw e
+  }
+}
+
+function loadDhtState (file) {
+  var dhtStateJson = readDhtState(file)
+  if (!dhtStateJson) return null
+  var dhtState = parseDhtState(dhtStateJson)
+  if (!dhtState) return null
+  return dhtState
+}
+
+function loadDhtNodes (file) {
+  var dhtState = loadDhtState(file)
+  if (!dhtState) return null
+  if (!('nodes' in dhtState)) return null
+  var nodes = dhtState.nodes
+  if (!Array.isArray(nodes)) return null
+  if (nodes.length === 0) return null // Don't load an empty nodes list
+  return nodes
+}
+
+module.exports = {
+  save: saveDhtState,
+  loadNodes: loadDhtNodes
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://webtorrent.io"
   },
   "browser": {
+    "./lib/dhtpersist.js": false,
     "./lib/server.js": false,
     "./lib/tcp-pool.js": false,
     "bittorrent-dht/client": false,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "addr-to-ip-port": "^1.4.2",
+    "app-data-folder": "^1.0.0",
     "bitfield": "^2.0.0",
     "bittorrent-dht": "^8.0.0",
     "bittorrent-protocol": "^2.1.5",
@@ -40,6 +41,7 @@
     "load-ip-set": "^1.2.7",
     "memory-chunk-store": "^1.2.0",
     "mime": "^2.2.0",
+    "mkdirp": "^0.5.1",
     "multistream": "^2.0.5",
     "package-json-versionify": "^1.0.2",
     "parse-numeric-range": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "serve-static": "^1.11.1",
     "standard": "*",
     "tape": "^4.6.0",
+    "tmp": "0.0.33",
     "webtorrent-fixtures": "^1.5.0"
   },
   "engines": {

--- a/test/node/persist-dht-nodes.js
+++ b/test/node/persist-dht-nodes.js
@@ -1,0 +1,41 @@
+var test = require('tape')
+var tmp = require('tmp')
+var fs = require('fs')
+var DHT = require('bittorrent-dht/server')
+var WebTorrent = require('../../')
+
+var localHost = '127.0.0.1'
+var port = 9999
+
+test('Save DHT state', function (t) {
+  t.plan(4)
+  var saveFile = tmp.tmpNameSync()
+  var dhtServer = new DHT({ bootstrap: false })
+  dhtServer.on('error', function (err) { t.fail(err) })
+  dhtServer.on('warning', function (err) { t.fail(err) })
+  dhtServer.listen(port, function handleServerListening () {
+    var client = new WebTorrent({
+      dht: { bootstrap: false },
+      dhtState: saveFile
+    })
+    client.on('error', function (err) { t.fail(err) })
+    client.on('warning', function (err) { t.fail(err) })
+    client.dht.addNode({ host: localHost, port: port })
+    client.dht.on('node', function handleNodeAdded () {
+      client.saveDhtState(function handleDhtStateSaved () {
+        var dhtStateJson = fs.readFileSync(saveFile)
+        var dhtState = JSON.parse(dhtStateJson)
+        var nodes = dhtState.nodes
+        var node = nodes[0]
+        t.equal(node.host, localHost)
+        t.equal(node.port, port)
+        client.destroy(function handleClientDestroyed (err) {
+          t.error(err, 'client destroyed')
+        })
+        dhtServer.destroy(function handleDhtServerDestroyed (err) {
+          t.error(err, 'dht server destroyed')
+        })
+      })
+    })
+  })
+})

--- a/test/node/persist-dht-nodes.js
+++ b/test/node/persist-dht-nodes.js
@@ -18,7 +18,7 @@ test('Save DHT state', function (t) {
   dhtServer.listen(port, function handleServerListening () {
     var client = new WebTorrent({
       dht: { bootstrap: false, host: localAddress },
-      dhtState: saveFile
+      persistDhtPath: saveFile
     })
     client.on('error', function (err) { t.fail(err) })
     client.on('warning', function (err) { t.fail(err) })
@@ -59,7 +59,7 @@ test('Load DHT state', function (t) {
   dhtServer.listen(port, function handleServerListening () {
     var client = new WebTorrent({
       dht: { host: localAddress },
-      dhtState: saveFile
+      persistDhtPath: saveFile
     })
     client.on('error', function (err) { t.fail(err) })
     client.on('warning', function (err) { t.fail(err) })

--- a/test/node/persist-dht-nodes.js
+++ b/test/node/persist-dht-nodes.js
@@ -1,13 +1,15 @@
 var test = require('tape')
 var tmp = require('tmp')
 var fs = require('fs')
+var networkAddress = require('network-address')
 var DHT = require('bittorrent-dht/server')
 var WebTorrent = require('../../')
 
-var localHost = '127.0.0.1'
+var loopback = '127.0.0.1'
+var localAddress = networkAddress.ipv4()
 var port = 9999
 
-test('Save DHT state', function (t) {
+test.only('Save DHT state', function (t) {
   t.plan(4)
   var saveFile = tmp.tmpNameSync()
   var dhtServer = new DHT({ bootstrap: false })
@@ -15,19 +17,19 @@ test('Save DHT state', function (t) {
   dhtServer.on('warning', function (err) { t.fail(err) })
   dhtServer.listen(port, function handleServerListening () {
     var client = new WebTorrent({
-      dht: { bootstrap: false },
+      dht: { bootstrap: false, host: localAddress },
       dhtState: saveFile
     })
     client.on('error', function (err) { t.fail(err) })
     client.on('warning', function (err) { t.fail(err) })
-    client.dht.addNode({ host: localHost, port: port })
+    client.dht.addNode({ host: loopback, port: port })
     client.dht.on('node', function handleNodeAdded () {
       client.saveDhtState(function handleDhtStateSaved () {
         var dhtStateJson = fs.readFileSync(saveFile)
         var dhtState = JSON.parse(dhtStateJson)
         var nodes = dhtState.nodes
         var node = nodes[0]
-        t.equal(node.host, localHost)
+        t.equal(node.host, loopback)
         t.equal(node.port, port)
         client.destroy(function handleClientDestroyed (err) {
           t.error(err, 'client destroyed')


### PR DESCRIPTION
Persists DHT nodes to disk every 15 minutes.
Loads persisted nodes on construction.
Enabled by default.

Default save file is `dht.json`, under crossplatform app data folder provided by `app-data-folder`.

Adds option `dhtState` to configure:
* false disables
* true enables with default path
* String specifies path to custom save file

Closes #72.