### PR TITLE
Add opts.skipVerify to skip verifying existing data

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -74,6 +74,7 @@ function Torrent (torrentId, client, opts) {
   this.urlList = opts.urlList
 
   this.path = opts.path
+  this.skipVerify = !!opts.skipVerify
   this._store = opts.store || FSChunkStore
   this._getAnnounceOpts = opts.getAnnounceOpts
 
@@ -542,29 +543,33 @@ Torrent.prototype._onMetadata = function (metadata) {
     self._onWireWithMetadata(wire)
   })
 
-  self._debug('verifying existing torrent data')
-  if (self._fileModtimes && self._store === FSChunkStore) {
-    // don't verify if the files haven't been modified since we last checked
-    self.getFileModtimes(function (err, fileModtimes) {
-      if (err) return self._destroy(err)
-
-      var unchanged = self.files.map(function (_, index) {
-        return fileModtimes[index] === self._fileModtimes[index]
-      }).every(function (x) {
-        return x
-      })
-
-      if (unchanged) {
-        for (var index = 0; index < self.pieces.length; index++) {
-          self._markVerified(index)
-        }
-        self._onStore()
-      } else {
-        self._verifyPieces()
-      }
-    })
+  if (self.skipVerify) {
+    // Skip verifying exisitng data and just assume it's correct
+    self._markAllVerified()
+    self._onStore()
   } else {
-    self._verifyPieces()
+    self._debug('verifying existing torrent data')
+    if (self._fileModtimes && self._store === FSChunkStore) {
+      // don't verify if the files haven't been modified since we last checked
+      self.getFileModtimes(function (err, fileModtimes) {
+        if (err) return self._destroy(err)
+
+        var unchanged = self.files.map(function (_, index) {
+          return fileModtimes[index] === self._fileModtimes[index]
+        }).every(function (x) {
+          return x
+        })
+
+        if (unchanged) {
+          self._markAllVerified()
+          self._onStore()
+        } else {
+          self._verifyPieces()
+        }
+      })
+    } else {
+      self._verifyPieces()
+    }
   }
 
   self.emit('metadata')
@@ -621,6 +626,12 @@ Torrent.prototype._verifyPieces = function () {
     self._debug('done verifying')
     self._onStore()
   })
+}
+
+Torrent.prototype._markAllVerified = function () {
+  for (var index = 0; index < this.pieces.length; index++) {
+    this._markVerified(index)
+  }
 }
 
 Torrent.prototype._markVerified = function (index) {
@@ -1625,11 +1636,7 @@ Torrent.prototype.load = function (streams, cb) {
 
   pump(readable, writable, function (err) {
     if (err) return cb(err)
-    self.pieces.forEach(function (piece, index) {
-      self.pieces[index] = null
-      self._reservations[index] = null
-      self.bitfield.set(index, true)
-    })
+    self._markAllVerified()
     self._checkDone()
     cb(null)
   })


### PR DESCRIPTION
This is useful for the internet archive case where the chunk store lazily fetches chunks from the network.