### PR TITLE
Torrent to pass discovery interval to torrent-discovery

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -341,7 +341,7 @@ Torrent.prototype._onListening = function () {
     tracker: trackerOpts,
     port: self.client.torrentPort,
     userAgent: USER_AGENT,
-    discoveryIntervalMs: self.discoveryIntervalMs
+    intervalMs: self.discoveryIntervalMs
   })
 
   self.discovery.on('error', onError)

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -72,6 +72,7 @@ function Torrent (torrentId, client, opts) {
 
   this.announce = opts.announce
   this.urlList = opts.urlList
+  this.discoveryIntervalMs = opts.discoveryIntervalMs
 
   this.path = opts.path
   this.skipVerify = !!opts.skipVerify
@@ -339,7 +340,8 @@ Torrent.prototype._onListening = function () {
     dht: !self.private && self.client.dht,
     tracker: trackerOpts,
     port: self.client.torrentPort,
-    userAgent: USER_AGENT
+    userAgent: USER_AGENT,
+    discoveryIntervalMs: self.discoveryIntervalMs
   })
 
   self.discovery.on('error', onError)


### PR DESCRIPTION
`torrent-discovery` supports accepting `intervalMs` in its constructor, for changing the interval for discovering new peers (e.g. querying the DHT).
However, passing this argument is not yet supported in the main WebTorrent client which uses this package. This PR enables it.

Sometimes it makes a lot of sense to adjust the interval of querying the DHT for updates, for example if you want shorter discovery intervals than the 15 minutes default.