### PR TITLE
Add package-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+package-lock.json


### PR DESCRIPTION
Seems like a good idea since npm automatically creates it.

At the very least it would remove a minor annoyance