### PR TITLE
Indexeddb chunk store in browser

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -45,7 +45,8 @@ const PIPELINE_MAX_DURATION = 1
 const RECHOKE_INTERVAL = 10000 // 10 seconds
 const RECHOKE_OPTIMISTIC_DURATION = 2 // 30 seconds
 
-const FILESYSTEM_CONCURRENCY = 2
+// IndexedDB chunk stores used in the browser benefit from maximum concurrency
+const FILESYSTEM_CONCURRENCY = process.browser ? Infinity : 2
 
 const RECONNECT_WAIT = [ 1000, 5000, 15000 ]
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -459,7 +459,8 @@ class Torrent extends EventEmitter {
           length: file.length,
           offset: file.offset
         })),
-        length: this.length
+        length: this.length,
+        name: this.infoHash
       })
     )
 


### PR DESCRIPTION
~~Here's the chunk store used https://github.com/KayleePop/idbkv-chunk-store
which is built on this IndexedDB wrapper https://github.com/KayleePop/idb-kv~~

~~`npm run size` shows this branch's bundle to be `85,873 bytes` which compared to the `85,252 bytes` of master is a .7% increase or 621 bytes larger~~

&nbsp;

Here's a deployment of instant.io using this PR's code for demo and smoke testing https://instant-io-idbkv.glitch.me/ (glitch.com is awesome)

Things to test (please share results :smile: ):
- Very large files
- Concurrent downloads of different torrents
- Reload tab to load persisted data from disk
  - After download has finished
  - While download is still going
- Multiple browser tabs (they use the same indexeddb database)
- RAM usage
- Speed compared to https://instant.io
  - Speed of completing download
  - downloading the file to disk
- Streaming
- Different browsers

EDIT: The default-chunk-store is no longer changed in this PR