### PR TITLE
calculate file downloaded correctly

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -36,18 +36,30 @@ class File extends EventEmitter {
 
   get downloaded () {
     if (!this._torrent.bitfield) return 0
-    let downloaded = 0
-    for (let index = this._startPiece; index <= this._endPiece; ++index) {
-      if (this._torrent.bitfield.get(index)) {
+
+    const { pieces, bitfield, pieceLength } = this._torrent
+    const { _startPiece:start, _endPiece:end } = this
+    const piece = pieces[start]
+
+    // Calculate first piece diffrently, it sometimes have a offset
+    let downloaded = bitfield.get(start)
+      ? pieceLength - this.offset
+      : Math.max(piece.length - piece.missing - this.offset, 0)
+
+    for (let index = start + 1; index <= end; ++index) {
+      if (bitfield.get(index)) {
         // verified data
-        downloaded += (index === this._endPiece) ? this._torrent.lastPieceLength : this._torrent.pieceLength
+        downloaded += pieceLength
       } else {
         // "in progress" data
-        const piece = this._torrent.pieces[index]
+        const piece = pieces[index]
         downloaded += piece.length - piece.missing
       }
     }
-    return downloaded
+
+    // We don't have a end-offset and one small file can fith in the middle
+    // of one chunk, so return this.length if it's oversized
+    return Math.min(downloaded, this.length)
   }
 
   get progress () {

--- a/lib/file.js
+++ b/lib/file.js
@@ -38,7 +38,7 @@ class File extends EventEmitter {
     if (!this._torrent.bitfield) return 0
 
     const { pieces, bitfield, pieceLength } = this._torrent
-    const { _startPiece:start, _endPiece:end } = this
+    const { _startPiece: start, _endPiece: end } = this
     const piece = pieces[start]
 
     // Calculate first piece diffrently, it sometimes have a offset

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -112,7 +112,7 @@ test('client.seed: filesystem path to folder with one file, string', function (t
 })
 
 test('client.seed: filesystem path to folder with multiple files, string', function (t) {
-  t.plan(6)
+  t.plan(7)
 
   var client = new WebTorrent({ dht: false, tracker: false })
 
@@ -123,6 +123,17 @@ test('client.seed: filesystem path to folder with multiple files, string', funct
     t.equal(client.torrents.length, 1)
     t.equal(torrent.infoHash, fixtures.numbers.parsedTorrent.infoHash)
     t.equal(torrent.magnetURI, fixtures.numbers.magnetURI)
+
+    const downloaded = torrent.files.map(file => ({
+      length: file.length,
+      downloaded: file.downloaded
+    }))
+
+    t.deepEqual(downloaded, [
+      { length: 1, downloaded: 1 },
+      { length: 2, downloaded: 2 },
+      { length: 3, downloaded: 3 }
+    ], 'expected downloaded to be calculated correctly')
 
     client.remove(torrent, function (err) { t.error(err, 'torrent destroyed') })
     t.equal(client.torrents.length, 0)


### PR DESCRIPTION
I notice `file.download` is calculated wrong.

Using the Sintel torrent as an example...
https://instant.io/#08ada5a7a6183aae1e09d831df6748d566095a10
(this can be tested in the console)

It has 6 srt files and 1 small piece of the mp4 file in the first piece
after the first piece is downloaded you can see that the first files are complete but the `progress` and `downloaded` are incorrect

```js
const file = client.get('08ada5a7a6183aae1e09d831df6748d566095a10').files[0]
console.log(file.done) // true
console.log(file.progress) // 39.58777239709443 <- incorrect b/c of download
console.log(file.downloaded) // 65399 <- this file fits inside one chunk and it's too big
console.log(file.length) // 1652
```