### PR TITLE
Try to reduce dl impact on slow computers (web)

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1138,7 +1138,17 @@ class Torrent extends EventEmitter {
     const ite = randomIterate(this.wires)
     let wire
     while ((wire = ite())) {
-      this._updateWire(wire)
+      this._updateWireWrapper(wire)
+    }
+  }
+
+  _updateWireWrapper (wire) {
+    const self = this
+
+    if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
+      window.requestIdleCallback(function () { self._updateWire(wire) })
+    } else {
+      self._updateWire(wire)
     }
   }
 
@@ -1156,11 +1166,7 @@ class Torrent extends EventEmitter {
     if (wire.requests.length >= minOutstandingRequests) return
     const maxOutstandingRequests = getBlockPipelineLength(wire, PIPELINE_MAX_DURATION)
 
-    if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
-      window.requestIdleCallback(function () { trySelectWire(false) || trySelectWire(true) })
-    } else {
-      trySelectWire(false) || trySelectWire(true)
-    }
+    trySelectWire(false) || trySelectWire(true)
 
     function genPieceFilterFunc (start, end, tried, rank) {
       return i => i >= start && i <= end && !(i in tried) && wire.peerPieces.get(i) && (!rank || rank(i))

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1156,7 +1156,11 @@ class Torrent extends EventEmitter {
     if (wire.requests.length >= minOutstandingRequests) return
     const maxOutstandingRequests = getBlockPipelineLength(wire, PIPELINE_MAX_DURATION)
 
-    trySelectWire(false) || trySelectWire(true)
+    if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
+      window.requestIdleCallback(function () { trySelectWire(false) || trySelectWire(true) })
+    } else {
+      trySelectWire(false) || trySelectWire(true)
+    }
 
     function genPieceFilterFunc (start, end, tried, rank) {
       return i => i >= start && i <= end && !(i in tried) && wire.peerPieces.get(i) && (!rank || rank(i))


### PR DESCRIPTION
On slow computers with a fast network, web browsers may no longer respond because webtorrent is downloading chunks too fast.

The main issue is that you cannot stream a video torrent: the web browser does not have time to play the video, it is too busy downloading the video chunks.

On web browser supporting [requestIdleCallback](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback#See_also), we download chunks with a lower priority allowing the web browser to execute other tasks (like playing the video).