### PR TITLE
ability to close and restore streaming server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -15,11 +15,11 @@ function Server (torrent, opts = {}) {
   const _listen = server.listen
   const _close = server.close
 
-  server.listen = port => {
+  server.listen = (...args) => {
     closed = false
     server.on('connection', onConnection)
     server.on('request', onRequest)
-    _listen.call(server, port)
+    _listen.apply(server, args)
   }
 
   server.close = cb => {
@@ -42,6 +42,7 @@ function Server (torrent, opts = {}) {
     if (!cb) cb = () => {}
     if (closed) process.nextTick(cb)
     else server.close(cb)
+    torrent = null
   }
 
   function isOriginAllowed (req) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,11 +12,16 @@ function Server (torrent, opts = {}) {
   const sockets = []
   const pendingReady = []
   let closed = false
-
-  server.on('connection', onConnection)
-  server.on('request', onRequest)
-
+  const _listen = server.listen
   const _close = server.close
+
+  server.listen = port => {
+    closed = false
+    server.on('connection', onConnection)
+    server.on('request', onRequest)
+    _listen.call(server, port)
+  }
+
   server.close = cb => {
     closed = true
     server.removeListener('connection', onConnection)
@@ -25,7 +30,6 @@ function Server (torrent, opts = {}) {
       const onReady = pendingReady.pop()
       torrent.removeListener('ready', onReady)
     }
-    torrent = null
     _close.call(server, cb)
   }
 


### PR DESCRIPTION
Added ability to restore steaming server by calling `.listen(port)` on existing server which was closed before with `.close()`

registered issue: https://github.com/webtorrent/webtorrent/issues/1545