### PR TITLE
chore: pin addr-to-ip-port to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/webtorrent/webtorrent/issues"
   },
   "dependencies": {
-    "addr-to-ip-port": "^1.4.2",
+    "addr-to-ip-port": "1.5.0",
     "bitfield": "^2.0.0",
     "bittorrent-dht": "^8.0.0",
     "bittorrent-protocol": "^2.1.5",


### PR DESCRIPTION
webtorrent