### PR TITLE
Allows customization of webseed http requests through an options call…

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -72,6 +72,7 @@ class Torrent extends EventEmitter {
     this.skipVerify = !!opts.skipVerify
     this._store = opts.store || FSChunkStore
     this._getAnnounceOpts = opts.getAnnounceOpts
+    this._getWebseedOpts = opts.getWebseedOpts
 
     this.strategy = opts.strategy || 'sequential'
 

--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -110,13 +110,16 @@ class WebConn extends Wire {
         'Requesting url=%s pieceIndex=%d offset=%d length=%d start=%d end=%d',
         url, pieceIndex, offset, length, start, end
       )
-      const opts = {
+      let opts = {
         url,
         method: 'GET',
         headers: {
           'user-agent': `WebTorrent/${VERSION} (https://webtorrent.io)`,
           range: `bytes=${start}-${end}`
         }
+      }
+      if (this._torrent._getWebseedOpts) {
+          opts = this._torrent._getWebseedOpts(opts)
       }
       function onResponse (res, data) {
         if (res.statusCode < 200 || res.statusCode >= 300) {

--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -119,7 +119,7 @@ class WebConn extends Wire {
         }
       }
       if (this._torrent._getWebseedOpts) {
-          opts = this._torrent._getWebseedOpts(opts)
+        opts = this._torrent._getWebseedOpts(opts)
       }
       function onResponse (res, data) {
         if (res.statusCode < 200 || res.statusCode >= 300) {


### PR DESCRIPTION
…back function.

This pull request allows users to modify the http options passed to `simple-get`, such as adding headers, query parameters, etc. `torrentOpts` now accepts a `getWebseedOpts` callback function, similar to `getAnnounceOpts`.

Relevant issues: 
https://github.com/webtorrent/webtorrent/issues/1507
https://github.com/webtorrent/webtorrent/issues/1530