### PR TITLE
Adds timeout option to requestIdleCallback

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1146,7 +1146,7 @@ class Torrent extends EventEmitter {
     const self = this
 
     if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
-      window.requestIdleCallback(function () { self._updateWire(wire) })
+      window.requestIdleCallback(function () { self._updateWire(wire) }, { timeout: 250 })
     } else {
       self._updateWire(wire)
     }


### PR DESCRIPTION
This is a modification of a previous pull request: https://github.com/webtorrent/webtorrent/pull/1513

Downloads will sometimes stall for several seconds, then resume after I click on the page, or blur the current window, or in any way cause `requestIdleCallback` to trigger. In some cases, the callback will never trigger if I reload the page and don't interact with it.

Delayed downloads are fine for streaming media since the user can consume the beginning chunks while later chunks get throttled, but for static media like images which need to render ASAP, the delayed download is counter productive. 

I propose adding the `timeout` option which will guarantee that the callback runs in a reasonable time, while still allowing some idle time.

Note that the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) recommend a timeout.

> A timeout option is strongly recommended for required work, as otherwise it's possible multiple seconds will elapse before the callback is fired.