### PR TITLE
Handle reserved characters in filepaths

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -26,7 +26,7 @@ const uniq = require('uniq')
 const utMetadata = require('ut_metadata')
 const utPex = require('ut_pex') // browser exclude
 const parseRange = require('parse-numeric-range')
-const filenameReservedRegex = require('filename-reserved-regex')
+const safeFilename = require('safe-filename')
 
 const File = require('./file')
 const Peer = require('./peer')
@@ -448,7 +448,7 @@ class Torrent extends EventEmitter {
     }
 
     this._rarityMap = new RarityMap(this)
-    this.files.each(file => file.path = file.path.replace(filenameReservedRegex(), '_'))
+    this.files.forEach(file => file.path = safeFilename.path(file.path))
 
     this.store = new ImmediateChunkStore(
       new this._store(this.pieceLength, {

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -26,6 +26,7 @@ const uniq = require('uniq')
 const utMetadata = require('ut_metadata')
 const utPex = require('ut_pex') // browser exclude
 const parseRange = require('parse-numeric-range')
+const filenameReservedRegex = require('filename-reserved-regex')
 
 const File = require('./file')
 const Peer = require('./peer')
@@ -447,6 +448,7 @@ class Torrent extends EventEmitter {
     }
 
     this._rarityMap = new RarityMap(this)
+    this.files.each(file => file.path = file.path.replace(filenameReservedRegex(), '_'))
 
     this.store = new ImmediateChunkStore(
       new this._store(this.pieceLength, {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "webtorrent-jali",
+  "name": "webtorrent",
   "description": "Streaming torrent client",
   "version": "0.103.1b",
   "author": {
@@ -23,7 +23,7 @@
     ]
   },
   "bugs": {
-    "url": "https://github.com/Jaliborc/webtorrent/issues"
+    "url": "https://github.com/webtorrent/webtorrent/issues"
   },
   "dependencies": {
     "addr-to-ip-port": "^1.4.2",
@@ -108,7 +108,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/Jaliborc/webtorrent.git"
+    "url": "git://github.com/webtorrent/webtorrent.git"
   },
   "scripts": {
     "build": "browserify -s WebTorrent -e ./ | minify > webtorrent.min.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webtorrent",
   "description": "Streaming torrent client",
-  "version": "0.103.1b",
+  "version": "0.103.1",
   "author": {
     "name": "WebTorrent, LLC",
     "email": "feross@webtorrent.io",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webtorrent-jali",
   "description": "Streaming torrent client",
-  "version": "0.103.1+1",
+  "version": "0.103.1b",
   "author": {
     "name": "WebTorrent, LLC",
     "email": "feross@webtorrent.io",
@@ -34,7 +34,6 @@
     "create-torrent": "^3.33.0",
     "debug": "^4.1.0",
     "end-of-stream": "^1.1.0",
-    "filename-reserved-regex": "^2.0.0",
     "fs-chunk-store": "^1.6.2",
     "immediate-chunk-store": "^2.0.0",
     "load-ip-set": "^2.1.0",
@@ -53,6 +52,7 @@
     "run-parallel": "^1.1.6",
     "run-parallel-limit": "^1.0.3",
     "safe-buffer": "^5.0.1",
+    "safe-filename": "^1.0.1",
     "simple-concat": "^1.0.0",
     "simple-get": "^3.0.1",
     "simple-peer": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "webtorrent",
+  "name": "webtorrent-jali",
   "description": "Streaming torrent client",
-  "version": "0.103.1",
+  "version": "0.103.1+1",
   "author": {
     "name": "WebTorrent, LLC",
     "email": "feross@webtorrent.io",
@@ -23,7 +23,7 @@
     ]
   },
   "bugs": {
-    "url": "https://github.com/webtorrent/webtorrent/issues"
+    "url": "https://github.com/Jaliborc/webtorrent/issues"
   },
   "dependencies": {
     "addr-to-ip-port": "^1.4.2",
@@ -34,6 +34,7 @@
     "create-torrent": "^3.33.0",
     "debug": "^4.1.0",
     "end-of-stream": "^1.1.0",
+    "filename-reserved-regex": "^2.0.0",
     "fs-chunk-store": "^1.6.2",
     "immediate-chunk-store": "^2.0.0",
     "load-ip-set": "^2.1.0",
@@ -107,7 +108,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/webtorrent/webtorrent.git"
+    "url": "git://github.com/Jaliborc/webtorrent.git"
   },
   "scripts": {
     "build": "browserify -s WebTorrent -e ./ | minify > webtorrent.min.js",


### PR DESCRIPTION
These two lines of code additions show how you can easily make WebTorrent be able to handle torrents and files having paths using UNIX or POSIX reserved characters, like the majority of torrenting clients do.

It is using a tiny package I created for the purpose of replacing reserved characters with visually similar unicode characters.

See issue #1618 