### PR TITLE
Add torrent.rescanFiles() to allow manual verify

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -366,6 +366,14 @@ connections, nor does it pause the streams of existing connections or their wire
 
 Resume connecting to new peers.
 
+## `torrent.rescanFiles([function callback (err) {}])`
+
+Verify the hashes of all pieces in the store and update the bitfield for any new valid
+pieces. Useful if data has been added to the store outside WebTorrent, e.g. if another
+process puts a valid file in the right place. Once the scan is complete,
+`callback(null)` will be called (if provided), unless the torrent was destroyed during
+the scan, in which case `callback` will be called with an error.
+
 ## `torrent.on('infoHash', function () {})`
 
 Emitted when the info hash of the torrent has been determined.

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -505,6 +505,12 @@ class Torrent extends EventEmitter {
       this._markAllVerified()
       this._onStore()
     } else {
+      const onPiecesVerified = (err) => {
+        if (err) return this._destroy(err)
+        this._debug('done verifying')
+        this._onStore()
+      }
+
       this._debug('verifying existing torrent data')
       if (this._fileModtimes && this._store === FSChunkStore) {
         // don't verify if the files haven't been modified since we last checked
@@ -517,11 +523,11 @@ class Torrent extends EventEmitter {
             this._markAllVerified()
             this._onStore()
           } else {
-            this._verifyPieces()
+            this._verifyPieces(onPiecesVerified)
           }
         })
       } else {
-        this._verifyPieces()
+        this._verifyPieces(onPiecesVerified)
       }
     }
 
@@ -547,8 +553,8 @@ class Torrent extends EventEmitter {
     })
   }
 
-  _verifyPieces () {
-    parallelLimit(this.pieces.map((_, index) => cb => {
+  _verifyPieces (cb) {
+    parallelLimit(this.pieces.map((piece, index) => cb => {
       if (this.destroyed) return cb(new Error('torrent is destroyed'))
 
       this.store.get(index, (err, buf) => {
@@ -568,10 +574,21 @@ class Torrent extends EventEmitter {
           cb(null)
         })
       })
-    }), FILESYSTEM_CONCURRENCY, err => {
-      if (err) return this._destroy(err)
-      this._debug('done verifying')
-      this._onStore()
+    }), FILESYSTEM_CONCURRENCY, cb)
+  }
+
+  rescanFiles (cb) {
+    if (this.destroyed) throw new Error('torrent is destroyed')
+    if (!cb) cb = noop
+
+    this._verifyPieces((err) => {
+      if (err) {
+        this._destroy(err)
+        return cb(err)
+      }
+
+      this._checkDone()
+      cb(null)
     })
   }
 


### PR DESCRIPTION
Useful if files are modified externally to webtorrent. Needed for Internet Archive use case.