### PR TITLE
Fix error in Chrome extension environment

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -3,7 +3,7 @@ const http = require('http')
 const mime = require('mime')
 const pump = require('pump')
 const rangeParser = require('range-parser')
-const URL = require('url').URL
+const URL = require('url').URL || window.URL // TODO: remove when we drop Node 8 support
 
 function Server (torrent, opts = {}) {
   const server = http.createServer()


### PR DESCRIPTION
Video streaming is broken in Brave since they upgraded to WebTorrent v0.105.0. The root cause is described in this issue: https://github.com/brave/brave-browser/issues/5358

This is a quick fix. Once we drop support for Node, we can purge `require('url')` from across the codebase and just use the global `URL` everywhere. So, this fix can be removed then without affecting Brave.

Fixes https://github.com/brave/brave-browser/issues/5358