### PR TITLE
Fix server 'hostname' option to mitigate DNS rebinding attack

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -54,13 +54,6 @@ function Server (torrent, opts = {}) {
     // deny them
     if (req.headers.origin == null) return false
 
-    // If a 'hostname' string is specified, deny requests with a 'Host'
-    // header that does not match the origin of the torrent server to prevent
-    // DNS rebinding attacks.
-    if (opts.hostname && req.headers.host !== `${opts.hostname}:${server.address().port}`) {
-      return false
-    }
-
     // The user allowed all origins
     if (opts.origin === '*') return true
 
@@ -77,6 +70,13 @@ function Server (torrent, opts = {}) {
   }
 
   function onRequest (req, res) {
+    // If a 'hostname' string is specified, deny requests with a 'Host'
+    // header that does not match the origin of the torrent server to prevent
+    // DNS rebinding attacks.
+    if (opts.hostname && req.headers.host !== `${opts.hostname}:${server.address().port}`) {
+      return req.destroy()
+    }
+
     const pathname = new URL(req.url, 'http://example.com').pathname
 
     if (pathname === '/favicon.ico') {


### PR DESCRIPTION
It appears that this feature, originally added in https://github.com/webtorrent/webtorrent/pull/1260, may have never worked correctly.

When the request hostname does not match the user-provided opts.hostname value, we should stop processing the request and return nothing. Instead, what was happening was that we'd simply omit the Access-Control-Allow-Origin header, which is not sufficient since the whole point of DNS rebinding attacks is that they appear to be same origin and therefore don't require a CORS header.

cc @diracdeltas @yrliou