### PR TITLE
App "chromeapp" field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,12 @@
     "os": false,
     "ut_pex": false
   },
+  "chromeapp": {
+    "fs-chunk-store": "memory-chunk-store",
+    "http": "http-node",
+    "net": "chrome-net",
+    "os": false
+  },
   "browserify": {
     "transform": [
       "package-json-versionify"
@@ -30,11 +36,13 @@
     "bitfield": "^3.0.0",
     "bittorrent-dht": "^9.0.0",
     "bittorrent-protocol": "^3.0.0",
+    "chrome-net": "^3.3.2",
     "chunk-store-stream": "^4.0.0",
     "create-torrent": "^4.0.0",
     "debug": "^4.1.0",
     "end-of-stream": "^1.1.0",
     "fs-chunk-store": "^2.0.0",
+    "http-node": "feross/http-node#cddd2872f0020ecf5016f326cf5e58c965eef52a",
     "immediate-chunk-store": "^2.0.0",
     "load-ip-set": "^2.1.0",
     "memory-chunk-store": "^1.2.0",


### PR DESCRIPTION
For: https://github.com/brave/brave-browser/issues/5587

I'm attempting to make a defacto standard for specifying Chrome App dependency substitutions using the `"chromeapp"` field in `package.json`.

The `"chromeapp"` field is just like the [`"browser"` field in `package.json`](https://github.com/defunctzombie/package-browser-field-spec) except it's intended for Chrome Apps instead of a generic browser environment. Bundler tools like `browserify` or `webpack` can be configured to look for the `"chromeapp"` field instead of the `"browser"` field when doing a build for a Chrome App.

In this specific package, since Chrome Apps can use raw sockets we want to replace e.g. `require('net')` with `require('chrome-net')`.

I'm also sending PRs to all dependent projects that need substitutions to work in Chrome Apps.

- https://github.com/jscissr/http-node/pull/2
- https://github.com/webtorrent/torrent-discovery/pull/45
- https://github.com/mafintosh/k-rpc-socket/pull/17
- https://github.com/webtorrent/bittorrent-tracker/pull/328