### PR TITLE
Adds missing callback.

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -565,7 +565,7 @@ class Torrent extends EventEmitter {
           if (this.destroyed) return cb(new Error('torrent is destroyed'))
 
           if (hash === this._hashes[index]) {
-            if (!this.pieces[index]) return
+            if (!this.pieces[index]) return cb(null)
             this._debug('piece verified %s', index)
             this._markVerified(index)
           } else {


### PR DESCRIPTION
`torrent._verifyPieces()` is missing a callback invocation. Currently it hangs forever. I reached the conditional after calling `torrent.rescanFiles()`, which I believe is buggy and will file an issue for.