### PR TITLE
Notify caller of torrent creation in seed call

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,7 +267,7 @@ class WebTorrent extends EventEmitter {
     if (!opts.createdBy) opts.createdBy = `WebTorrent/${VERSION_STR}`
 
     const onTorrent = torrent => {
-      opts.onTorrent && opts.onTorrent(torrent);
+      opts.onTorrent && opts.onTorrent(torrent)
       const tasks = [
         cb => {
           // when a filesystem path is specified, files are already in the FS store

--- a/index.js
+++ b/index.js
@@ -267,6 +267,7 @@ class WebTorrent extends EventEmitter {
     if (!opts.createdBy) opts.createdBy = `WebTorrent/${VERSION_STR}`
 
     const onTorrent = torrent => {
+      opts.onTorrent && opts.onTorrent(torrent);
       const tasks = [
         cb => {
           // when a filesystem path is specified, files are already in the FS store


### PR DESCRIPTION
onseed gets called a bit after the actual torrent file is parsed and complete.  I have a progress bar for the torrent creation but there's an indeterminate amount of time between onTorrent and onSeed.