### PR TITLE
Allow multiple remove/add calls for a torrent object

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,7 +234,7 @@ class WebTorrent extends EventEmitter {
     this._debug('add')
     opts = opts ? Object.assign({}, opts) : {}
 
-    const torrent = new Torrent(torrentId, this, opts)
+    const torrent = torrentId instanceof Torrent ? torrentId : new Torrent(torrentId, this, opts)
     this.torrents.push(torrent)
 
     torrent.once('_infoHash', onInfoHash)


### PR DESCRIPTION
torrent object were created each time, even if torrentId was already a torrent.