### PR TITLE
destroy videostream (if any) when file is destroyed.

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -119,7 +119,7 @@ class File extends EventEmitter {
 
   renderTo (elem, opts, cb) {
     if (typeof window === 'undefined') throw new Error('browser-only method')
-    render.render(this, elem, opts, cb)
+    this._stream = render.render(this, elem, opts, cb)
   }
 
   _getMimeType () {
@@ -129,6 +129,8 @@ class File extends EventEmitter {
   _destroy () {
     this._destroyed = true
     this._torrent = null
+    this._stream && this._stream.destroy()
+    this._stream = null
   }
 }
 


### PR DESCRIPTION
for use with https://github.com/feross/render-media/pull/70 to clean up errors