### PR TITLE
Update jsdelivr URLs to use latest WebTorrent

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -231,7 +231,7 @@ clients like Transmission, and uTorrent to add support for WebTorrent. **Vuze**
 ## How do I get started?
 
 To start using WebTorrent, simply include the
-[`webtorrent.min.js`](https://cdn.jsdelivr.net/webtorrent/latest/webtorrent.min.js)
+[`webtorrent.min.js`](https://cdn.jsdelivr.net/npm/webtorrent@latest/webtorrent.min.js)
 script on your page. If you use [browserify](http://browserify.org/), you can
 `npm install webtorrent` and `require('webtorrent')`.
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -6,7 +6,7 @@ to get started!
 ## Install
 
 To start using WebTorrent, simply include the
-[`webtorrent.min.js`](https://cdn.jsdelivr.net/webtorrent/latest/webtorrent.min.js)
+[`webtorrent.min.js`](https://cdn.jsdelivr.net/npm/webtorrent@latest/webtorrent.min.js)
 script on your page.
 
 ```html
@@ -129,7 +129,7 @@ downloaded.
     <div class="log"></div>
 
     <!-- Include the latest version of WebTorrent -->
-    <script src="https://cdn.jsdelivr.net/webtorrent/latest/webtorrent.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/webtorrent@latest/webtorrent.min.js"></script>
 
     <script>
       var client = new WebTorrent()
@@ -282,7 +282,7 @@ or [Instant.io](https://instant.io) to seed torrents to the WebTorrent network.
       </div>
     </div>
     <!-- Include the latest version of WebTorrent -->
-    <script src="https://cdn.jsdelivr.net/webtorrent/latest/webtorrent.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/webtorrent@latest/webtorrent.min.js"></script>
 
     <!-- Moment is used to show a human-readable remaining time -->
     <script src="http://momentjs.com/downloads/moment.min.js"></script>


### PR DESCRIPTION
Noticed a few places where the old jsdelivr url was being used. This old URL causes the old 0.98.18 version of webtorrent to be used.