### PR TITLE
Emit `metadata` before `ready` and `done`

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -505,6 +505,9 @@ class Torrent extends EventEmitter {
       this._onWireWithMetadata(wire)
     })
 
+    // Emit 'metadata' before 'ready' and 'done'
+    this.emit('metadata')
+
     if (this.skipVerify) {
       // Skip verifying exisitng data and just assume it's correct
       this._markAllVerified()
@@ -535,8 +538,6 @@ class Torrent extends EventEmitter {
         this._verifyPieces(onPiecesVerified)
       }
     }
-
-    this.emit('metadata')
   }
 
   /*


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Regarding events, I think it is important the order in which they are emitted.

If I'm correct, the usual order in which `torrent` events are emitted should be:

```
infoHash
metadata
ready
done
```

But right now, the `metadata` event is emitted the last one. This PR fixes the order of this event. And maybe fixes [webtorrent-desktop#1429](https://github.com/webtorrent/webtorrent-desktop/issues/1429). I'm not sure since I was not able to reproduce the bug with the *exact* same steps. But, at least, the order is now (as I believe) correct.

**Is there anything you'd like reviewers to focus on?**

They should focus on staying awesome ;)