### PR TITLE
Fix how the first piece's irrelevant bytes are calculated

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -41,10 +41,12 @@ class File extends EventEmitter {
     const { _startPiece: start, _endPiece: end } = this
     const piece = pieces[start]
 
-    // Calculate first piece diffrently, it sometimes have a offset
+    // First piece may have an offset, e.g. irrelevant bytes from the end of
+    // the previous file
+    const irrelevantFirstPieceBytes = this.offset % pieceLength
     let downloaded = bitfield.get(start)
-      ? pieceLength - (this.offset % pieceLength)
-      : Math.max(piece.length - piece.missing - this.offset, 0)
+      ? pieceLength - irrelevantFirstPieceBytes
+      : Math.max(pieceLength - irrelevantFirstPieceBytes - piece.missing, 0)
 
     for (let index = start + 1; index <= end; ++index) {
       if (bitfield.get(index)) {
@@ -53,12 +55,12 @@ class File extends EventEmitter {
       } else {
         // "in progress" data
         const piece = pieces[index]
-        downloaded += piece.length - piece.missing
+        downloaded += pieceLength - piece.missing
       }
     }
 
-    // We don't have a end-offset and one small file can fith in the middle
-    // of one chunk, so return this.length if it's oversized
+    // We don't know the end offset, so return this.length if it's oversized.
+    // e.g. One small file can fit in the middle of a piece.
     return Math.min(downloaded, this.length)
   }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

Noticed that the fix to use modulo on the offset from https://github.com/webtorrent/webtorrent/pull/1592 wasn't applied to the second case.

**Is there anything you'd like reviewers to focus on?**

Nope