### PR TITLE
Fix parsed torrent

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -196,7 +196,7 @@ class Torrent extends EventEmitter {
 
     let parsedTorrent
     try { parsedTorrent = parseTorrent(torrentId) } catch (err) {}
-    if (parsedTorrent) {
+    if (parsedTorrent && parsedTorrent.infoHash) {
       // Attempt to set infoHash property synchronously
       this.infoHash = parsedTorrent.infoHash
       this._debugId = parsedTorrent.infoHash.toString('hex').substring(0, 7)

--- a/test/client-add.js
+++ b/test/client-add.js
@@ -207,6 +207,7 @@ test('client.add: invalid torrent id: short buffer', function (t) {
 })
 
 test('client.add: non-bittorrent URNs', function (t) {
+  // Non-bittorrent URNs (examples from Wikipedia)
   const magnets = [
     'magnet:?xt=urn:sha1:PDAQRAOQQRYS76MRZJ33LK4MMVZBDSCL',
     'magnet:?xt=urn:tree:tiger:IZZG2KNL4BKA7LYEKK5JAX6BQ27UV4QZKPL2JZQ',
@@ -227,12 +228,10 @@ test('client.add: non-bittorrent URNs', function (t) {
     t.ok(err.message.indexOf('Invalid torrent identifier') >= 0)
 
     done += 1
-
     if (done === magnets.length) client.destroy(function (err) { t.error(err, 'client destroyed') })
   })
   client.on('warning', function (err) { t.fail(err) })
 
-  // Non-bittorrent URNs (examples from Wikipedia)
   magnets.forEach(function (magnet) {
     client.add(magnet)
   })

--- a/test/client-add.js
+++ b/test/client-add.js
@@ -205,3 +205,35 @@ test('client.add: invalid torrent id: short buffer', function (t) {
 
   client.add(Buffer.from('abc'))
 })
+
+test('client.add: non-bittorrent URNs', function (t) {
+  const magnets = [
+    'magnet:?xt=urn:sha1:PDAQRAOQQRYS76MRZJ33LK4MMVZBDSCL',
+    'magnet:?xt=urn:tree:tiger:IZZG2KNL4BKA7LYEKK5JAX6BQ27UV4QZKPL2JZQ',
+    'magnet:?xt=urn:bitprint:QBMYI5FTYSFFSP7HJ37XALYNNVYLJE27.E6ITPBX6LSBBW34T3UGPIVJDNNJZIQOMP5WNEUI',
+    'magnet:?xt=urn:ed2k:31D6CFE0D16AE931B73C59D7E0C089C0',
+    'magnet:?xt=urn:aich:D6EUDGK2DBTBEZ2XVN3G6H4CINSTZD7M',
+    'magnet:?xt=urn:kzhash:35759fdf77748ba01240b0d8901127bfaff929ed1849b9283f7694b37c192d038f535434',
+    'magnet:?xt=urn:md5:4e7bef74677be349ccffc6a178e38299'
+  ]
+
+  t.plan(magnets.length * 2 + 1)
+
+  var done = 0
+  var client = new WebTorrent({ dht: false, tracker: false })
+
+  client.on('error', function (err) {
+    t.ok(err instanceof Error)
+    t.ok(err.message.indexOf('Invalid torrent identifier') >= 0)
+
+    done += 1
+
+    if (done === magnets.length) client.destroy(function (err) { t.error(err, 'client destroyed') })
+  })
+  client.on('warning', function (err) { t.fail(err) })
+
+  // Non-bittorrent URNs (examples from Wikipedia)
+  magnets.forEach(function (magnet) {
+    client.add(magnet)
+  })
+})


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**
Fixes issue [webtorrent-cli#64](https://github.com/webtorrent/webtorrent-cli/issues/64).

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
This PR checks that the `parsedTorrent` has an `infoHash`. If so, this means it is a valid Bittorrent magnet. Thus, other magnets, like the ones used by Gnutella (e.g. `magnet:?xt=urn:sha1:PD...`), are not valid.

Also this PR adds a test to check this behaviour.

**Which issue (if any) does this pull request address?**
[webtorrent-cli#64](https://github.com/webtorrent/webtorrent-cli/issues/64)

**Is there anything you'd like reviewers to focus on?**
