### PR TITLE
Fix infinite loop bug

### DIFF
--- a/lib/rarity-map.js
+++ b/lib/rarity-map.js
@@ -10,21 +10,21 @@ class RarityMap {
     this._pieces = new Array(this._numPieces)
 
     this._onWire = wire => {
-      this.recalculate()
+      this._dirty = true
       this._initWire(wire)
     }
     this._onWireHave = index => {
       this._pieces[index] += 1
     }
     this._onWireBitfield = () => {
-      this.recalculate()
+      this._dirty = true
     }
 
     this._torrent.wires.forEach(wire => {
       this._initWire(wire)
     })
     this._torrent.on('wire', this._onWire)
-    this.recalculate()
+    this._dirty = true
   }
 
   /**
@@ -35,6 +35,11 @@ class RarityMap {
    * @return {number} index of rarest piece, or -1
    */
   getRarestPiece (pieceFilterFunc) {
+    if (this._dirty) {
+      this._dirty = false
+      this.recalculate()
+    }
+
     let candidates = []
     let min = Infinity
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1545,6 +1545,10 @@ class Torrent extends EventEmitter {
       })
     })
 
+    // the wire may be choking or closed
+    if (numRequests === wire.requests.length)
+      return false
+
     function onUpdateTick () {
       process.nextTick(() => { self._update() })
     }

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1546,8 +1546,9 @@ class Torrent extends EventEmitter {
     })
 
     // the wire may be choking or closed
-    if (numRequests === wire.requests.length)
+    if (numRequests === wire.requests.length) {
       return false
+    }
 
     function onUpdateTick () {
       process.nextTick(() => { self._update() })

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1171,14 +1171,23 @@ class Torrent extends EventEmitter {
    * Heartbeat to update all peers and their requests.
    */
   _update () {
-    if (this.destroyed) return
-
-    // update wires in random order for better request distribution
-    const ite = randomIterate(this.wires)
-    let wire
-    while ((wire = ite())) {
-      this._updateWireWrapper(wire)
+    if (this._updateScheduled) {
+      this._debug('_update already queued')
+      return
     }
+
+    this._updateScheduled = true
+    setTimeout(() => {
+      this._updateScheduled = false
+      if (this.destroyed) return
+
+      // update wires in random order for better request distribution
+      const ite = randomIterate(this.wires)
+      let wire
+      while ((wire = ite())) {
+        this._updateWireWrapper(wire)
+      }
+    }, 1000)
   }
 
   _updateWireWrapper (wire) {

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -117,6 +117,7 @@ class Torrent extends EventEmitter {
     // TODO: remove this and expose a hook instead
     // optimization: don't recheck every file if it hasn't changed
     this._fileModtimes = opts.fileModtimes
+    this._verifyPiece = opts.verifyPiece
 
     if (torrentId !== null) this._onTorrentId(torrentId)
 
@@ -566,6 +567,14 @@ class Torrent extends EventEmitter {
     parallelLimit(this.pieces.map((piece, index) => cb => {
       if (this.destroyed) return cb(new Error('torrent is destroyed'))
 
+      if (this._verifyPiece) {
+        if (this._verifyPiece(index, this._hashes[index], this.infoHash)) {
+          this._debug('piece verified %s', index)
+          this._markVerified(index)
+        }
+        return process.nextTick(cb, null)
+      }
+
       this.store.get(index, (err, buf) => {
         if (this.destroyed) return cb(new Error('torrent is destroyed'))
 
@@ -611,6 +620,7 @@ class Torrent extends EventEmitter {
     this.pieces[index] = null
     this._reservations[index] = null
     this.bitfield.set(index, true)
+    this.emit('verified', index, this._hashes[index])
   }
 
   /**
@@ -1527,6 +1537,7 @@ class Torrent extends EventEmitter {
           self.pieces[index] = null
           self._reservations[index] = null
           self.bitfield.set(index, true)
+          self.emit('verified', index, hash)
 
           self.store.put(index, buf)
 


### PR DESCRIPTION
The wire request may fail due to choking or wire closed. This results in an infinite loop.

Here is where "false" is expected, otherwise it loops infinitely:
https://github.com/koush/webtorrent/blob/master/lib/torrent.js#L1316

The failure is reported in the callback, but not as a return value:
https://github.com/webtorrent/bittorrent-protocol/blob/master/index.js#L316

Alternatively, the peer choking check can be done in the while loop.

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Watch for a failed wire request (number of requests does not change), and return false.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
