### PR TITLE
Check if client is set when debug logging.

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1630,7 +1630,7 @@ class Torrent extends EventEmitter {
 
   _debug () {
     const args = [].slice.call(arguments)
-    args[0] = `[${this.client._debugId}] [${this._debugId}] ${args[0]}`
+    args[0] = `[${this.client ? this.client._debugId : 'No Client'}] [${this._debugId}] ${args[0]}`
     debug(...args)
   }
 


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

I check if the torrent's `client` is defined before using its debugId.

**Which issue (if any) does this pull request address?**

https://github.com/webtorrent/webtorrent/issues/1800
