### PR TITLE
downgrade end-of-stream to v1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chunk-store-stream": "^4.0.0",
     "create-torrent": "^4.0.0",
     "debug": "^4.1.0",
-    "end-of-stream": "^1.1.0",
+    "end-of-stream": "1.4.1",
     "escape-html": "^1.0.3",
     "fs-chunk-store": "^2.0.0",
     "http-node": "github:feross/http-node#webtorrent",


### PR DESCRIPTION
The minor update in our version range was breaking. We can update it later when it's fixed. 

even without an NPM bump, this patch is useful to just let the CI tests work

issue: https://github.com/webtorrent/webtorrent/issues/1757 (should maybe keep that open until we can re-enable updates for the package though)
