### PR TITLE
Mark webseeds interested at the start, ensuring they download anything

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1094,6 +1094,8 @@ class Torrent extends EventEmitter {
     if (wire.type !== 'webSeed') { // do not choke on webseeds
       timeoutId = setTimeout(onChokeTimeout, CHOKE_TIMEOUT)
       if (timeoutId.unref) timeoutId.unref()
+    } else { // mark webseeds interested
+      wire.interested()
     }
 
     wire.isSeeder = false


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
I've made it so there is a call to `wire.interested()` for webseed peers since it was discovered on the issue linked below that the `wire.uninterested()` further up in the file was preventing webseeds from working correctly.

I tested this manually with webseeds using a similar bit of code to the one in the issue below.

**Which issue (if any) does this pull request address?**
#1671 
possibly others

**Is there anything you'd like reviewers to focus on?**
I'd like to be sure of the correctness of this, particularly if I might have affected anything other than webseeds.