### PR TITLE
Change parseRange.parse to parseRange

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -480,7 +480,7 @@ class Torrent extends EventEmitter {
 
     // Select only specified files (BEP53) http://www.bittorrent.org/beps/bep_0053.html
     if (this.so) {
-      const selectOnlyFiles = parseRange.parse(this.so)
+      const selectOnlyFiles = parseRange(this.so)
 
       this.files.forEach((v, i) => {
         if (selectOnlyFiles.includes(i)) this.files[i].select(true)


### PR DESCRIPTION
node-parse-numeric-range does not support parse function as of Jan 6, 2020. Refer commit https://github.com/euank/node-parse-numeric-range/commit/9483328128c7d639361e3395ecb8a2b21fe07de4 .

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Changed parseRange.parse to parseRange
**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
