### PR TITLE
Fix setting initial interest

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1084,7 +1084,7 @@ class Torrent extends EventEmitter {
     })
 
     wire.bitfield(this.bitfield) // always send bitfield (required)
-    wire.uninterested() // always start out uninterested (as per protocol)
+    this._updateWireInterest(wire) // set inital interest
 
     // Send PORT message to peers that support DHT
     if (wire.peerExtensions.dht && this.client.dht && this.client.dht.listening) {
@@ -1147,22 +1147,24 @@ class Torrent extends EventEmitter {
     const prev = this._amInterested
     this._amInterested = !!this._selections.length
 
-    this.wires.forEach(wire => {
-      let interested = false
-      for (let index = 0; index < this.pieces.length; ++index) {
-        if (this.pieces[index] && wire.peerPieces.get(index)) {
-          interested = true
-          break
-        }
-      }
-
-      if (interested) wire.interested()
-      else wire.uninterested()
-    })
+    this.wires.forEach(wire => this._updateWireInterest(wire))
 
     if (prev === this._amInterested) return
     if (this._amInterested) this.emit('interested')
     else this.emit('uninterested')
+  }
+
+  _updateWireInterest (wire) {
+    let interested = false
+    for (let index = 0; index < this.pieces.length; ++index) {
+      if (this.pieces[index] && wire.peerPieces.get(index)) {
+        interested = true
+        break
+      }
+    }
+
+    if (interested) wire.interested()
+    else wire.uninterested()
   }
 
   /**

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1048,11 +1048,13 @@ class Torrent extends EventEmitter {
     wire.on('bitfield', () => {
       updateSeedStatus()
       this._update()
+      this._updateWireInterest(wire)
     })
 
     wire.on('have', () => {
       updateSeedStatus()
       this._update()
+      this._updateWireInterest(wire)
     })
 
     wire.once('interested', () => {
@@ -1084,7 +1086,9 @@ class Torrent extends EventEmitter {
     })
 
     wire.bitfield(this.bitfield) // always send bitfield (required)
-    this._updateWireInterest(wire) // set inital interest
+
+    // initialize interest in case bitfield message was already received before above handler was registered
+    this._updateWireInterest(wire)
 
     // Send PORT message to peers that support DHT
     if (wire.peerExtensions.dht && this.client.dht && this.client.dht.listening) {

--- a/test/node/download-from-ip.js
+++ b/test/node/download-from-ip.js
@@ -1,0 +1,54 @@
+const fixtures = require('webtorrent-fixtures')
+const fs = require('fs')
+const MemoryChunkStore = require('memory-chunk-store')
+const test = require('tape')
+const WebTorrent = require('../../')
+
+test('Download via torrent.addPeer()', (t) => {
+  t.plan(7)
+  // if initial interest isn't set, then this test is delayed
+  t.timeoutAfter(5000)
+
+  const seeder = new WebTorrent({ tracker: false, dht: false })
+
+  seeder.on('error', (err) => t.fail(err))
+  seeder.on('warning', (err) => t.fail(err))
+
+  const torrent = seeder.add(fixtures.leaves.parsedTorrent, { store: MemoryChunkStore })
+
+  torrent.on('ready', function () {
+    // torrent metadata has been fetched -- sanity check it
+    t.equal(torrent.name, 'Leaves of Grass by Walt Whitman.epub')
+
+    var names = ['Leaves of Grass by Walt Whitman.epub']
+    t.deepEqual(torrent.files.map(function (file) { return file.name }), names)
+  })
+
+  torrent.load(fs.createReadStream(fixtures.leaves.contentPath), (err) => {
+    t.error(err)
+
+    // torrent data now loaded into seeder
+
+    const downloader = new WebTorrent({ tracker: false, dht: false })
+
+    downloader.on('error', function (err) { t.fail(err) })
+    downloader.on('warning', function (err) { t.fail(err) })
+
+    downloader.add(fixtures.leaves.parsedTorrent, { store: MemoryChunkStore }, (torrent) => {
+      torrent.addPeer(`localhost:${seeder.torrentPort}`)
+
+      torrent.once('done', function () {
+        torrent.files.forEach((file) => {
+          file.getBuffer((err, buf) => {
+            t.error(err)
+
+            t.deepEqual(buf, fixtures.leaves.content, 'downloaded correct content')
+
+            seeder.destroy((err) => t.error(err, 'seeder destroyed'))
+            downloader.destroy((err) => t.error(err, 'downloader destroyed'))
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
fixes https://github.com/webtorrent/webtorrent/issues/1864 by actually checking whether we're interested instead of always setting uninterested initially

It looks like in https://github.com/webtorrent/webtorrent/pull/1061 they misread the spec and thought that "Connections start out choked and not interested" meant that we had to send an uninterested message on start (but it really means lack of any message means not interested, at least I think)

@paullouisageneau could you see if this fixes your issue in libtorrent as well?