### PR TITLE
refactor _rechoke()

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1348,71 +1348,79 @@ class Torrent extends EventEmitter {
   _rechoke () {
     if (!this.ready) return
 
-    if (this._rechokeOptimisticTime > 0) this._rechokeOptimisticTime -= 1
-    else this._rechokeOptimisticWire = null
+    // wires in increasing order of quality (pop() gives next best peer)
+    const wireStack =
+      this.wires
+        .map(wire => ({ wire, random: Math.random() })) // insert a random seed for randomizing the sort
+        .sort((objA, objB) => {
+          const wireA = objA.wire
+          const wireB = objB.wire
 
-    const peers = []
+          // prefer peers that send us data faster
+          if (wireA.downloadSpeed() !== wireB.downloadSpeed()) {
+            return wireA.downloadSpeed() - wireB.downloadSpeed()
+          }
 
-    this.wires.forEach(wire => {
-      if (!wire.isSeeder && wire !== this._rechokeOptimisticWire) {
-        peers.push({
-          wire,
-          downloadSpeed: wire.downloadSpeed(),
-          uploadSpeed: wire.uploadSpeed(),
-          salt: Math.random(),
-          isChoked: true
+          // then prefer peers that can download data from us faster
+          if (wireA.uploadSpeed() !== wireB.uploadSpeed()) {
+            return wireA.uploadSpeed() - wireB.uploadSpeed()
+          }
+
+          // then prefer already unchoked peers (to minimize fibrillation)
+          if (wireA.amChoking !== wireB.amChoking) {
+            return wireA.amChoking ? -1 : 1 // choking < unchoked
+          }
+
+          // otherwise random order
+          return objA.random - objB.random
         })
-      }
-    })
+        .map(obj => obj.wire) // return array of wires (remove random seed)
 
-    peers.sort(rechokeSort)
-
-    let unchokeInterested = 0
-    let i = 0
-    for (; i < peers.length && unchokeInterested < this._rechokeNumSlots; ++i) {
-      peers[i].isChoked = false
-      if (peers[i].wire.peerInterested) unchokeInterested += 1
+    if (this._rechokeOptimisticTime <= 0) {
+      // clear old optimistic peer, so it can be rechoked normally and then replaced
+      this._rechokeOptimisticWire = null
+    } else {
+      this._rechokeOptimisticTime -= 1
     }
 
-    // Optimistically unchoke a peer
-    if (!this._rechokeOptimisticWire && i < peers.length && this._rechokeNumSlots) {
-      const candidates = peers.slice(i).filter(peer => peer.wire.peerInterested)
-      const optimistic = candidates[randomInt(candidates.length)]
+    let numInterestedUnchoked = 0
+    // leave one rechoke slot open for optimistic unchoking
+    while (wireStack.length > 0 && numInterestedUnchoked < this._rechokeNumSlots - 1) {
+      const wire = wireStack.pop() // next best quality peer
 
-      if (optimistic) {
-        optimistic.isChoked = false
-        this._rechokeOptimisticWire = optimistic.wire
+      if (wire.isSeeder || wire === this._rechokeOptimisticWire) {
+        continue
+      }
+
+      wire.unchoke()
+
+      // only stop unchoking once we fill the slots with interested peers that will actually download
+      if (wire.peerInterested) {
+        numInterestedUnchoked++
+      }
+    }
+
+    // fill optimistic unchoke slot if empty
+    if (this._rechokeOptimisticWire === null && this._rechokeNumSlots > 0) {
+      // don't optimistically unchoke uninterested peers
+      const remaining = wireStack.filter(wire => wire.peerInterested)
+
+      if (remaining.length > 0) {
+        // select random remaining (not yet unchoked) peer
+        const newOptimisticPeer = remaining[randomInt(remaining.length)]
+
+        newOptimisticPeer.unchoke()
+
+        this._rechokeOptimisticWire = newOptimisticPeer
+
         this._rechokeOptimisticTime = RECHOKE_OPTIMISTIC_DURATION
       }
     }
 
-    // Unchoke best peers
-    peers.forEach(peer => {
-      if (peer.wire.amChoking !== peer.isChoked) {
-        if (peer.isChoked) peer.wire.choke()
-        else peer.wire.unchoke()
-      }
-    })
-
-    function rechokeSort (peerA, peerB) {
-      // Prefer higher download speed
-      if (peerA.downloadSpeed !== peerB.downloadSpeed) {
-        return peerB.downloadSpeed - peerA.downloadSpeed
-      }
-
-      // Prefer higher upload speed
-      if (peerA.uploadSpeed !== peerB.uploadSpeed) {
-        return peerB.uploadSpeed - peerA.uploadSpeed
-      }
-
-      // Prefer unchoked
-      if (peerA.wire.amChoking !== peerB.wire.amChoking) {
-        return peerA.wire.amChoking ? 1 : -1
-      }
-
-      // Random order
-      return peerA.salt - peerB.salt
-    }
+    // choke the rest
+    wireStack
+      .filter(wire => wire !== this._rechokeOptimisticWire) // except the optimistically unchoked peer
+      .forEach(wire => wire.choke())
   }
 
   /**


### PR DESCRIPTION
~~https://github.com/webtorrent/webtorrent/issues/1871 fixed by checking if each peer is interested when unchoking. Before, uninterested peers would be unchoked as long as they weren't seeders~~

refactor torrent._rechoke() for readability. Behavior should be the same (can change to only unchoke interested peers later if we want)