### PR TITLE
feat: rescan of torrent should get all (in)valid events

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -714,6 +714,13 @@ file.getBlobURL(function (err, url) {
 })
 ```
 
+## `file.includes(piece)`
+Check if the piece number contains this file's data.
+
+## `file.on('done', function () {})`
+
+Emitted when the file has been downloaded.
+
 # Piece API
 
 ## `piece.length`

--- a/lib/file.js
+++ b/lib/file.js
@@ -144,6 +144,10 @@ class File extends EventEmitter {
     render.render(this, elem, opts, cb)
   }
 
+  includes (piece) {
+    return this._startPiece <= piece && this._endPiece >= piece
+  }
+
   _getMimeType () {
     return render.mime[path.extname(this.name).toLowerCase()]
   }

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -620,12 +620,7 @@ class Torrent extends EventEmitter {
             this._debug('piece verified %s', index)
             this._markVerified(index)
           } else {
-            this.pieces[index] = new Piece(piece.length || this.pieceLength)
-            this.bitfield.set(index, false)
-            this.select(index, index, 1)
-            this.files.forEach(file => {
-              if (file.done && file.includes(index)) file.done = false
-            })
+            this._markUnVerified(index)
             this._debug('piece invalid %s', index)
           }
           cb(null)
@@ -659,6 +654,18 @@ class Torrent extends EventEmitter {
     this.pieces[index] = null
     this._reservations[index] = null
     this.bitfield.set(index, true)
+  }
+
+  _markUnVerified (index) {
+    const len = (index === this.pieces.length - 1)
+      ? this.lastPieceLength
+      : this.pieceLength
+    this.pieces[index] = new Piece(len)
+    this.bitfield.set(index, false)
+    this.select(index, index, 1)
+    this.files.forEach(file => {
+      if (file.done && file.includes(index)) file.done = false
+    })
   }
 
   /**

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -103,6 +103,8 @@ class Torrent extends EventEmitter {
     this.metadata = null
     this.store = null
     this.files = []
+
+    // Pieces that need to be downloaded, indexed by piece index
     this.pieces = []
 
     this._amInterested = false
@@ -599,6 +601,10 @@ class Torrent extends EventEmitter {
   }
 
   _verifyPieces (cb) {
+    const done = () => {
+      this._checkDone()
+      cb()
+    }
     parallelLimit(this.pieces.map((piece, index) => cb => {
       if (this.destroyed) return cb(new Error('torrent is destroyed'))
 
@@ -618,12 +624,18 @@ class Torrent extends EventEmitter {
             this._debug('piece verified %s', index)
             this._markVerified(index)
           } else {
+            this.pieces[index] = new Piece(piece.length || this.pieceLength)
+            this.bitfield.set(index, false)
+            this.select(index, index, 1)
+            this.files.forEach(file => {
+              if (file.done && file.includes(index)) file.done = false
+            })
             this._debug('piece invalid %s', index)
           }
           cb(null)
         })
       })
-    }), FILESYSTEM_CONCURRENCY, cb)
+    }), FILESYSTEM_CONCURRENCY, done)
   }
 
   rescanFiles (cb) {
@@ -636,7 +648,6 @@ class Torrent extends EventEmitter {
         return cb(err)
       }
 
-      this._checkDone()
       cb(null)
     })
   }

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -620,7 +620,7 @@ class Torrent extends EventEmitter {
             this._debug('piece verified %s', index)
             this._markVerified(index)
           } else {
-            this._markUnVerified(index)
+            this._markUnverified(index)
             this._debug('piece invalid %s', index)
           }
           cb(null)
@@ -656,7 +656,7 @@ class Torrent extends EventEmitter {
     this.bitfield.set(index, true)
   }
 
-  _markUnVerified (index) {
+  _markUnverified (index) {
     const len = (index === this.pieces.length - 1)
       ? this.lastPieceLength
       : this.pieceLength

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -601,10 +601,6 @@ class Torrent extends EventEmitter {
   }
 
   _verifyPieces (cb) {
-    const done = () => {
-      this._checkDone()
-      cb()
-    }
     parallelLimit(this.pieces.map((piece, index) => cb => {
       if (this.destroyed) return cb(new Error('torrent is destroyed'))
 
@@ -635,7 +631,7 @@ class Torrent extends EventEmitter {
           cb(null)
         })
       })
-    }), FILESYSTEM_CONCURRENCY, done)
+    }), FILESYSTEM_CONCURRENCY, cb)
   }
 
   rescanFiles (cb) {
@@ -648,6 +644,7 @@ class Torrent extends EventEmitter {
         return cb(err)
       }
 
+      this._checkDone()
       cb(null)
     })
   }


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
When adding an existing, completed torrent file with `skipVerify` to speed client start time, calling rescanFiles would kick off a scan but only report invalid chunks, because this line short-circuited the call on verification success.

**Which issue (if any) does this pull request address?**
n/a

**Is there anything you'd like reviewers to focus on?**
can you document the importance of the this.pieces array somehow?   a few comments here and there would help me to understand what it means for them to be there or not.
