### PR TITLE
Fix BEP53 implementation

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -25,7 +25,6 @@ const speedometer = require('speedometer')
 const utMetadata = require('ut_metadata')
 const utPex = require('ut_pex') // browser exclude
 const utp = require('utp-native') // browser exclude
-const parseRange = require('parse-numeric-range')
 
 const File = require('./file')
 const Peer = require('./peer')
@@ -486,10 +485,12 @@ class Torrent extends EventEmitter {
 
     // Select only specified files (BEP53) http://www.bittorrent.org/beps/bep_0053.html
     if (this.so) {
-      const selectOnlyFiles = parseRange(this.so)
-
       this.files.forEach((v, i) => {
-        if (selectOnlyFiles.includes(i)) this.files[i].select(true)
+        if (this.so.includes(i)) {
+          this.files[i].select()
+        } else {
+          this.files[i].deselect()
+        }
       })
     } else {
       // start off selecting the entire torrent with low priority

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "mime": "^2.4.6",
     "multistream": "^4.0.0",
     "package-json-versionify": "^1.0.4",
-    "parse-numeric-range": "^1.2.0",
     "parse-torrent": "^9.0.0",
     "pump": "^3.0.0",
     "random-iterate": "^1.0.1",


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
This PR fixes the BEP53 implementation, as the actual code does not work properly https://github.com/webtorrent/webtorrent-desktop/issues/1852

**Which issue (if any) does this pull request address?**
The main issue is that the BEP53 `so` property is not available, as `magnet-uri`  inside `parse-torrent` does not implement BEP53 decoding. There is a PR in `magnet-uri` to solve this issue https://github.com/webtorrent/magnet-uri/pull/37

**Is there anything you'd like reviewers to focus on?**
Before this PR can be merged, we need to take some steps

- [x] Merge https://github.com/webtorrent/magnet-uri/pull/37
- [x] Publish new version of https://github.com/webtorrent/magnet-uri/
- [x] Publish new version of https://github.com/webtorrent/parse-torrent/
- [x] Update `package.json` dependencies