### PR TITLE
check if torrent is destroyed before emitting download/upload event

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -921,7 +921,8 @@ class Torrent extends EventEmitter {
       this._downloadSpeed(downloaded)
       this.client._downloadSpeed(downloaded)
       this.emit('download', downloaded)
-      if (this.client) this.client.emit('download', downloaded)
+      if (this.destroyed) return
+      this.client.emit('download', downloaded)
     })
 
     wire.on('upload', uploaded => {
@@ -930,7 +931,8 @@ class Torrent extends EventEmitter {
       this._uploadSpeed(uploaded)
       this.client._uploadSpeed(uploaded)
       this.emit('upload', uploaded)
-      if (this.client) this.client.emit('upload', uploaded)
+      if (this.destroyed) return
+      this.client.emit('upload', uploaded)
     })
 
     this.wires.push(wire)

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -921,7 +921,7 @@ class Torrent extends EventEmitter {
       this._downloadSpeed(downloaded)
       this.client._downloadSpeed(downloaded)
       this.emit('download', downloaded)
-      this.client.emit('download', downloaded)
+      if (this.client) this.client.emit('download', downloaded)
     })
 
     wire.on('upload', uploaded => {
@@ -930,7 +930,7 @@ class Torrent extends EventEmitter {
       this._uploadSpeed(uploaded)
       this.client._uploadSpeed(uploaded)
       this.emit('upload', uploaded)
-      this.client.emit('upload', uploaded)
+      if (this.client) this.client.emit('upload', uploaded)
     })
 
     this.wires.push(wire)


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
`Torrent.client` was emitting `download` and `upload` events without checking if `this.client` was still defined

**Which issue (if any) does this pull request address?**
This PR fixes #1924 and fixes #999 (duplicate).
