### PR TITLE
Remove erronous `.default` at the end of `require("bitfield").default`

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1,7 +1,7 @@
 /* global Blob */
 
 const addrToIPPort = require('addr-to-ip-port')
-const BitField = require('bitfield').default
+const BitField = require('bitfield')
 const ChunkStoreWriteStream = require('chunk-store-stream/write')
 const debug = require('debug')('webtorrent:torrent')
 const Discovery = require('torrent-discovery')

--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -1,4 +1,4 @@
-const BitField = require('bitfield').default
+const BitField = require('bitfield')
 const debug = require('debug')('webtorrent:webconn')
 const get = require('simple-get')
 const sha1 = require('simple-sha1')


### PR DESCRIPTION
[x] Bug fix

In `torrent.js` and `webconn.js`, bitfield is imported with `const BitField = require('bitfield').default`. However, the `default` property is nonexistent. 