### PR TITLE
correctly calculate file downloaded progress

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -60,9 +60,10 @@ class File extends EventEmitter {
       }
     }
 
-    // We don't know the end offset, so return this.length if it's oversized.
-    // e.g. One small file can fit in the middle of a piece.
-    return Math.min(downloaded, this.length)
+    const irrelevantLastPieceBytes = pieceLength - ((this.offset + this.length) % pieceLength)
+    downloaded -= irrelevantLastPieceBytes
+
+    return downloaded
   }
 
   get progress () {


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

`file.downloaded` returns the wrong value when a file ends partway through a piece. It counts the whole piece as downloaded, even if the last part of the piece is not used by the given file. We had a hack in place with `Math.min()` to ensure that the file download progress was never greater than 100%, but we should actually correctly return the downloaded amount.

**Which issue (if any) does this pull request address?**

None.

**Is there anything you'd like reviewers to focus on?**

None.