### PR TITLE
Support opts.preloadedStore in webtorrent.seed

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,8 +273,8 @@ class WebTorrent extends EventEmitter {
     const onTorrent = torrent => {
       const tasks = [
         cb => {
-          // when a filesystem path is specified, files are already in the FS store
-          if (isFilePath) return cb()
+          // when a filesystem path is specified or the store is preloaded, files are already in the FS store
+          if (isFilePath || opts.preloadedStore) return cb()
           torrent.load(streams, cb)
         }
       ]
@@ -304,7 +304,7 @@ class WebTorrent extends EventEmitter {
     else if (!Array.isArray(input)) input = [input]
 
     parallel(input.map(item => cb => {
-      if (isReadable(item)) {
+      if (!opts.preloadedStore && isReadable(item)) {
         concat(item, (err, buf) => {
           if (err) return cb(err)
           buf.name = item.name

--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -53,7 +53,10 @@ class FileStream extends stream.Readable {
     if (this._torrent.destroyed) return this._destroy(new Error('Torrent removed'))
 
     const p = this._piece
-    this._torrent.store.get(p, (err, buffer) => {
+    const length = p === this._torrent.pieces.length - 1 ? this._torrent.lastPieceLength : undefined
+    this._torrent.store.get(p, {
+      length
+    }, (err, buffer) => {
       this._notifying = false
       if (this.destroyed) return
       debug('read %s (length %s) (err %s)', p, buffer.length, err && err.message)

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -71,6 +71,7 @@ class Torrent extends EventEmitter {
     this.path = opts.path
     this.skipVerify = !!opts.skipVerify
     this._store = opts.store || FSChunkStore
+    this._preloadedStore = opts.preloadedStore || null
     this._getAnnounceOpts = opts.getAnnounceOpts
 
     // if defined, `opts.private` overrides default privacy of torrent
@@ -470,7 +471,7 @@ class Torrent extends EventEmitter {
     this._rarityMap = new RarityMap(this)
 
     this.store = new ImmediateChunkStore(
-      new this._store(this.pieceLength, {
+      this._preloadedStore || new this._store(this.pieceLength, {
         torrent: {
           infoHash: this.infoHash
         },
@@ -584,7 +585,11 @@ class Torrent extends EventEmitter {
     parallelLimit(this.pieces.map((piece, index) => cb => {
       if (this.destroyed) return cb(new Error('torrent is destroyed'))
 
-      this.store.get(index, (err, buf) => {
+      const length = index === this.pieces.length - 1 ? this.lastPieceLength : undefined
+
+      this.store.get(index, {
+        length
+      }, (err, buf) => {
         if (this.destroyed) return cb(new Error('torrent is destroyed'))
 
         if (err) return queueMicrotask(() => cb(null)) // ignore error


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

opts.preloadedStore can be used to seed a torrent using a store that already contains data.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
