### PR TITLE
feat: support adding paused torrents.

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -94,7 +94,7 @@ class Torrent extends EventEmitter {
 
     this.ready = false
     this.destroyed = false
-    this.paused = false
+    this.paused = opts.paused || false
     this.done = false
 
     this.metadata = null

--- a/test/client-add.js
+++ b/test/client-add.js
@@ -205,3 +205,24 @@ test('client.add: invalid torrent id: short buffer', function (t) {
 
   client.add(Buffer.from('abc'))
 })
+
+test('client.add: paused torrent', function (t) {
+  t.plan(5)
+
+  const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
+
+  client.on('error', function (err) { t.fail(err) })
+  client.on('warning', function (err) { t.fail(err) })
+
+  const torrent = client.add(fixtures.leaves.magnetURI, { paused: true })
+  t.equal(client.torrents.length, 1)
+
+  torrent.on('infoHash', function () {
+    t.equal(torrent.paused, true)
+
+    client.remove(fixtures.leaves.magnetURI, function (err) { t.error(err, 'torrent destroyed') })
+    t.equal(client.torrents.length, 0)
+
+    client.destroy(function (err) { t.error(err, 'client destroyed') })
+  })
+})

--- a/test/client-add.js
+++ b/test/client-add.js
@@ -211,8 +211,8 @@ test('client.add: paused torrent', function (t) {
 
   const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
 
-  client.on('error', function (err) { t.fail(err) })
-  client.on('warning', function (err) { t.fail(err) })
+  client.on('error', (err) => t.fail(err))
+  client.on('warning', (err) => t.fail(err))
 
   const torrent = client.add(fixtures.leaves.magnetURI, { paused: true })
   t.equal(client.torrents.length, 1)


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] New feature

**What changes did you make? (Give an overview)**

The use case I'd like to solve is that a torrent file and it's contents are stored in disk, I'd like to add the torrent to the `client` and be able to benefit from the programmatic interface provided by `client`, `torrent`, and `file`; without being connected to peers.

Another example, if I `pause` a torrent and restart my application, I'd like to maintain that state across restarts.

Adding a torrent to the client and then pausing it is not an adequate workaround.

**Which issue (if any) does this pull request address?**

N/A

**Is there anything you'd like reviewers to focus on?**

I'm new to your code, I'm unaware if I'm changing everything that's necessary. I wanted to be able to send a PR and not just create an issue / feature request.