### PR TITLE
don't throw when logging null/undef buffer

### DIFF
--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -59,7 +59,7 @@ class FileStream extends stream.Readable {
     }, (err, buffer) => {
       this._notifying = false
       if (this.destroyed) return
-        debug('read %s (length %s) (err %s)', p, buffer && buffer.length, err && err.message)
+      debug('read %s (length %s) (err %s)', p, buffer && buffer.length, err && err.message)
 
       if (err) return this._destroy(err)
 

--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -59,7 +59,7 @@ class FileStream extends stream.Readable {
     }, (err, buffer) => {
       this._notifying = false
       if (this.destroyed) return
-      debug('read %s (length %s) (err %s)', p, buffer.length, err && err.message)
+        debug('read %s (length %s) (err %s)', p, buffer && buffer.length, err && err.message)
 
       if (err) return this._destroy(err)
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Fixed an issue where file-stream would throw if it has a reference to a undefined/null buffer

**Which issue (if any) does this pull request address?**
n/a

**Is there anything you'd like reviewers to focus on?**
