### PR TITLE
Destroy torrent if putting into store fails

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1599,7 +1599,9 @@ class Torrent extends EventEmitter {
           self._reservations[index] = null
           self.bitfield.set(index, true)
 
-          self.store.put(index, buf)
+          self.store.put(index, buf, err => {
+            if (err) self._destroy(err)
+          })
 
           self.wires.forEach(wire => {
             wire.have(index)


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Errors writing pieces into the store were being silently ignored. Instead, destroy the torrent with an error.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
