### PR TITLE
fix: RTC peer garbage collection in Chromium

### DIFF
--- a/hacks.js
+++ b/hacks.js
@@ -1,0 +1,27 @@
+// Addresses an issue where RTC peers are not properly garbage collected in Chromium:
+// https://bugs.chromium.org/p/chromium/issues/detail?id=825576
+// This error leads to WebTorrent Desktop and Chromium-based browsers being completely
+// unable to seed until the process is restarted:
+// https://github.com/webtorrent/webtorrent/issues/1981
+let gcInterval = 1
+function forcePeerGC () {
+  let peer = new RTCPeerConnection()
+  setTimeout(() => {
+    peer.close()
+    peer = null
+  }, 10)
+  console.log(gcInterval++)
+  if (!(gcInterval % 20)) {
+    queueMicrotask(() => {
+      console.log('Collecting garbage.')
+      let img = document.createElement('img')
+      img.src = window.URL.createObjectURL(new Blob([new ArrayBuffer(5e+7)]))
+      img.onerror = function () {
+        window.URL.revokeObjectURL(this.src)
+        img = null
+      }
+    })
+  }
+}
+
+setInterval(forcePeerGC, 5000)

--- a/hacks.js
+++ b/hacks.js
@@ -3,25 +3,15 @@
 // This error leads to WebTorrent Desktop and Chromium-based browsers being completely
 // unable to seed until the process is restarted:
 // https://github.com/webtorrent/webtorrent/issues/1981
-let gcInterval = 1
 function forcePeerGC () {
-  let peer = new RTCPeerConnection()
-  setTimeout(() => {
-    peer.close()
-    peer = null
-  }, 10)
-  console.log(gcInterval++)
-  if (!(gcInterval % 20)) {
-    queueMicrotask(() => {
-      console.log('Collecting garbage.')
-      let img = document.createElement('img')
-      img.src = window.URL.createObjectURL(new Blob([new ArrayBuffer(5e+7)]))
-      img.onerror = function () {
-        window.URL.revokeObjectURL(this.src)
-        img = null
-      }
-    })
-  }
+  queueMicrotask(() => {
+    let img = document.createElement('img')
+    img.src = window.URL.createObjectURL(new Blob([new ArrayBuffer(5e+7)]))
+    img.onerror = function () {
+      window.URL.revokeObjectURL(this.src)
+      img = null
+    }
+  })
 }
 
-setInterval(forcePeerGC, 5000)
+setInterval(forcePeerGC, 30000)

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const Peer = require('simple-peer')
 const randombytes = require('randombytes')
 const speedometer = require('speedometer')
 const queueMicrotask = require('queue-microtask')
-
+require('./hacks')
 const ConnPool = require('./lib/conn-pool') // browser exclude
 const Torrent = require('./lib/torrent')
 const VERSION = require('./package.json').version

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
   },
   "standard": {
     "ignore": [
+      "hacks.js",
       "webtorrent.min.js",
       "webtorrent.chromeapp.js"
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Added a function that forces RTC peer garbage collection every 60 seconds. 

**Which issue (if any) does this pull request address?**
This is a hack that addresses a bug in Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=825576

RTC peers are released too slowly, causing an error that breaks both WebTorrent Desktop and the browser-only version of WebTorrent (while running in Chromium browsers). The following error will be seen in WD's "Developer > Show WebTorrent Process" menu: _Failed to construct 'RTCPeerConnection': Cannot create so many PeerConnections_

When this occurs, WebTorrent is completely unable to seed data. It is permanently broken until the process has been restarted.

I, personally, have been fighting this issue for a couple of months now: https://github.com/webtorrent/webtorrent/issues/1981

The proposed change works immediately and effectively, without any noticeable side effects.

All credit goes to this guy for creating a solution: https://stackoverflow.com/questions/66546934/how-to-clear-closed-rtcpeerconnection

**Is there anything you'd like reviewers to focus on?**
I would like to merge this as soon as possible. I have a need to use WebTorrent Desktop at-scale, but it's all but useless in its current state, because of how quickly it breaks. WD can crash and fail to seed as quickly as 5 minutes after it's been restarted!

Thanks for your review!

Ink