### PR TITLE
Make file.downloaded getter not throw when destroyed

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -36,7 +36,7 @@ class File extends EventEmitter {
   }
 
   get downloaded () {
-    if (!this._torrent.bitfield) return 0
+    if (this._destroyed || !this._torrent.bitfield) return 0
 
     const { pieces, bitfield, pieceLength, lastPieceLength } = this._torrent
     const { _startPiece: start, _endPiece: end } = this


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

When the `file.downloaded` getter was called after the file (or associated torrent) was destroyed, it would throw.

Other methods on `file` still will throw if called once destroyed. But IMHO getters should be protected at least.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
