### PR TITLE
FileStream: remove onclose argument to destroy()

### DIFF
--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -85,11 +85,7 @@ class FileStream extends stream.Readable {
     this._piece += 1
   }
 
-  destroy (onclose) {
-    this._destroy(null, onclose)
-  }
-
-  _destroy (err, onclose) {
+  _destroy (err) {
     if (this.destroyed) return
     this.destroyed = true
 
@@ -99,7 +95,6 @@ class FileStream extends stream.Readable {
 
     if (err) this.emit('error', err)
     this.emit('close')
-    if (onclose) onclose()
   }
 }
 


### PR DESCRIPTION

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

FileStream: remove onclose argument to destroy(). This is a non-standard interface and it's confusing. It caused a bug in https://wormhole.app

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**

This is a breaking change, so we'll release it as a minor version (we're still below 1.0.0)
