### PR TITLE
fix: getAnnounceOpts

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -310,6 +310,8 @@ class Torrent extends EventEmitter {
     if (trackerOpts) {
       trackerOpts = Object.assign({}, this.client.tracker, {
         getAnnounceOpts: () => {
+          if (this.destroyed) return
+
           const opts = {
             uploaded: this.uploaded,
             downloaded: this.downloaded,


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
When the torrent is being destroyed the `this.client` attribute can be `null` before the `this.discovery` is fully destroyed.

This PR adds a check to return nothing in `getAnnounceOpts` when the torrent is already destroyed.

**Which issue (if any) does this pull request address?**
Fixes #2065 

**Is there anything you'd like reviewers to focus on?**
