### PR TITLE
let store access torrent/file events and figure out paths itself

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -555,7 +555,7 @@ File name, as specified by the torrent. *Example: 'some-filename.txt'*
 
 ## `file.path`
 
-File path, as specified by the torrent. *Example: 'some-folder/some-filename.txt'*
+File path, including torrent path. *Example: 'my-torrent/some-folder/some-filename.txt'*
 
 ## `file.length`
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -17,7 +17,7 @@ class File extends EventEmitter {
     this._fileStreams = new Set()
 
     this.name = file.name
-    this.path = file.path
+    this.path = path.join(torrent.path, file.path)
     this.length = file.length
     this.offset = file.offset
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -473,19 +473,14 @@ class Torrent extends EventEmitter {
 
     this._rarityMap = new RarityMap(this)
 
+    this.files = this.files.map(file => new File(this, file))
     let rawStore = this._preloadedStore
     if (!rawStore) {
       rawStore = new this._store(this.pieceLength, {
-        // opts.torrent is deprecated (replaced by the name property).
-        // it doesn't appear to be used by current versions of any stores on npm.
-        torrent: {
-          infoHash: this.infoHash
-        },
-        files: this.files.map(file => ({
-          path: path.join(this.path, file.path),
-          length: file.length,
-          offset: file.offset
-        })),
+        torrent: this,
+        path: this.path, // for stores that don't care about torrent
+        // files[n].path.startsWith(path) === true
+        files: this.files,
         length: this.length,
         name: this.infoHash
       })
@@ -501,8 +496,6 @@ class Torrent extends EventEmitter {
     this.store = new ImmediateChunkStore(
       rawStore
     )
-
-    this.files = this.files.map(file => new File(this, file))
 
     // Select only specified files (BEP53) http://www.bittorrent.org/beps/bep_0053.html
     if (this.so) {
@@ -587,7 +580,7 @@ class Torrent extends EventEmitter {
   getFileModtimes (cb) {
     const ret = []
     parallelLimit(this.files.map((file, index) => cb => {
-      fs.stat(path.join(this.path, file.path), (err, stat) => {
+      fs.stat(file.path, (err, stat) => {
         if (err && err.code !== 'ENOENT') return cb(err)
         ret[index] = stat && stat.mtime.getTime()
         cb(null)

--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const BitField = require('bitfield').default
 const debug = require('debug')('webtorrent:webconn')
 const get = require('simple-get')
@@ -103,7 +104,7 @@ class WebConn extends Wire {
         const fileEnd = requestedFile.offset + requestedFile.length - 1
         const url = this.url +
           (this.url[this.url.length - 1] === '/' ? '' : '/') +
-          requestedFile.path
+          path.relative(this.torrent.path, requestedFile.path)
         return {
           url,
           fileOffsetInRange: Math.max(requestedFile.offset - rangeStart, 0),


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Pass the Torrent and TorrentFile instances to the store to allow stores to make better decisions on how to eliminate file collisions.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
