### PR TITLE
fix: ensure uTP peer address is IPv4

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -762,8 +762,9 @@ class Torrent extends EventEmitter {
     if (this.destroyed) throw new Error('torrent is destroyed')
     if (!this.infoHash) throw new Error('addPeer() must not be called before the `infoHash` event')
 
+    let host
+
     if (this.client.blocked) {
-      let host
       if (typeof peer === 'string') {
         let parts
         try {
@@ -787,7 +788,10 @@ class Torrent extends EventEmitter {
     }
 
     // if the utp connection fails to connect, then it is replaced with a tcp connection to the same ip:port
-    const wasAdded = !!this._addPeer(peer, this.client.utp ? 'utp' : 'tcp')
+
+    const type = (this.client.utp && this._isIPv4(host)) ? 'utp' : 'tcp'
+    const wasAdded = !!this._addPeer(peer, type)
+
     if (wasAdded) {
       this.emit('peer', peer)
     } else {
@@ -1800,7 +1804,9 @@ class Torrent extends EventEmitter {
 
       const reconnectTimeout = setTimeout(() => {
         if (this.destroyed) return
-        const newPeer = this._addPeer(peer.addr, this.client.utp ? 'utp' : 'tcp')
+        const host = addrToIPPort(peer.addr)[0]
+        const type = (this.client.utp && this._isIPv4(host)) ? 'utp' : 'tcp'
+        const newPeer = this._addPeer(peer.addr, type)
         if (newPeer) newPeer.retries = peer.retries + 1
       }, ms)
       if (reconnectTimeout.unref) reconnectTimeout.unref()
@@ -1823,6 +1829,16 @@ class Torrent extends EventEmitter {
     const port = parts[1]
     return port > 0 && port < 65535 &&
       !(host === '127.0.0.1' && port === this.client.torrentPort)
+  }
+
+  /**
+   * Return `true` if string is a valid IPv4 address.
+   * @param {string} addr
+   * @return {boolean}
+   */
+  _isIPv4 (addr) {
+    const IPv4Pattern = /^((?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])[.]){3}(?:[0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$/
+    return IPv4Pattern.test(addr)
   }
 }
 


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Check peer address to ensure it is a valid IPv4 when using uTP protocol.

**Which issue (if any) does this pull request address?**
It should fix https://github.com/webtorrent/webtorrent/issues/2114

**Is there anything you'd like reviewers to focus on?**
I've added an internal `_isIPv4` method, just in case we want to replace its implementation with something different than https://github.com/sindresorhus/is-ip 
