### PR TITLE
fix: call public FileStream.destroy method so cb is defined

### DIFF
--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -59,7 +59,7 @@ class FileStream extends stream.Readable {
     if (this._notifying) return
     this._notifying = true
 
-    if (this._torrent.destroyed) return this._destroy(new Error('Torrent removed'))
+    if (this._torrent.destroyed) return this.destroy(new Error('Torrent removed'))
 
     const p = this._piece
 
@@ -73,7 +73,7 @@ class FileStream extends stream.Readable {
       if (this.destroyed) return
       debug('read %s (length %s) (err %s)', p, buffer && buffer.length, err && err.message)
 
-      if (err) return this._destroy(err)
+      if (err) return this.destroy(err)
 
       if (this._offset) {
         buffer = buffer.slice(this._offset)


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Previously, early exits in FileStream._notify would
throw since cb was not defined in _destroy

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
