### PR TITLE
fix: improve webseed speeds by using a single continuous stream

### DIFF
--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -23,8 +23,6 @@ function concat (chunks, size) {
   return b
 }
 
-const sleep = t => new Promise(resolve => setTimeout(resolve, t))
-
 class Queue {
   constructor () {
     this.queue = []
@@ -142,7 +140,7 @@ class WebConn extends Wire {
     }
 
     let { res, reader, endRange, setSize, ctrl } = this.lastRequest
-    for await (const request of requests) {
+    for await (const request of requests) { // controversial, but only make 1 request at a time
       const { url, start, end } = request
       function onResponse (res, data) {
         if (!res || res.status < 200 || res.status >= 300) {
@@ -199,11 +197,9 @@ class WebConn extends Wire {
             signal: ctrl.signal
           })
         } catch (e) {
-          this.sleep = sleep(500)
           onResponse()
           throw e
         }
-        this.sleep = sleep(500)
         reader = read(res.body.getReader(), 1)
         setSize = (await reader.next()).value // lazy, but 1st yield is callback x)
       }

--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -1,14 +1,57 @@
+/* global AbortController */
 const BitField = require('bitfield').default
-const debug = require('debug')('webtorrent:webconn')
-const get = require('simple-get')
-const ltDontHave = require('lt_donthave')
 const sha1 = require('simple-sha1')
 const Wire = require('bittorrent-protocol')
+const fetch = require('node-fetch')
 
 const VERSION = require('../package.json').version
 
-const SOCKET_TIMEOUT = 60000
-const RETRY_DELAY = 10000
+function concat (chunks, size) {
+  if (!size) {
+    size = 0
+    let i = chunks.length || chunks.byteLength || 0
+    while (i--) size += chunks[i].length
+  }
+  const b = new Uint8Array(size)
+  let offset = 0
+  for (let i = 0, l = chunks.length; i < l; i++) {
+    const chunk = chunks[i]
+    b.set(chunk, offset)
+    offset += chunk.byteLength || chunk.length
+  }
+
+  return b
+}
+
+const sleep = t => new Promise(resolve => setTimeout(resolve, t))
+
+class Queue {
+  constructor () {
+    this.queue = []
+    this.destroyed = false
+  }
+
+  add (fn) {
+    this.queue.push(fn)
+    if (!this.destroyed && this.queue.length === 1) this._next()
+  }
+
+  async _next () {
+    const fn = this.queue[0]
+    await fn()
+    this._remove()
+    if (!this.destroyed && this.queue.length) this._next()
+  }
+
+  _remove () {
+    if (!this.destroyed) this.queue.shift()
+  }
+
+  destroy () {
+    this.destroyed = true
+    this.queue = null
+  }
+}
 
 /**
  * Converts requests for torrent blocks into http range requests.
@@ -20,17 +63,20 @@ class WebConn extends Wire {
     super()
 
     this.url = url
-    this.connId = url // Unique id to deduplicate web seeds
-    this.webPeerId = sha1.sync(url) // Used as the peerId for this fake remote peer
+    this.connId = url
+    this.webPeerId = sha1.sync(url)
     this._torrent = torrent
+    this.lastRequest = {}
+
+    this.sleep = null
+
+    this.queue = new Queue()
 
     this._init()
   }
 
   _init () {
     this.setKeepAlive(true)
-
-    this.use(ltDontHave())
 
     this.once('handshake', (infoHash, peerId) => {
       if (this.destroyed) return
@@ -44,45 +90,22 @@ class WebConn extends Wire {
     })
 
     this.once('interested', () => {
-      debug('interested')
       this.unchoke()
     })
 
-    this.on('uninterested', () => { debug('uninterested') })
-    this.on('choke', () => { debug('choke') })
-    this.on('unchoke', () => { debug('unchoke') })
-    this.on('bitfield', () => { debug('bitfield') })
-    this.lt_donthave.on('donthave', () => { debug('donthave') })
-
     this.on('request', (pieceIndex, offset, length, callback) => {
-      debug('request pieceIndex=%d offset=%d length=%d', pieceIndex, offset, length)
-      this.httpRequest(pieceIndex, offset, length, (err, data) => {
-        if (err) {
-          // Cancel all in progress requests for this piece
-          this.lt_donthave.donthave(pieceIndex)
-
-          // Wait a little while before saying the webseed has the failed piece again
-          const retryTimeout = setTimeout(() => {
-            if (this.destroyed) return
-
-            this.have(pieceIndex)
-          }, RETRY_DELAY)
-          if (retryTimeout.unref) retryTimeout.unref()
-        }
-
+      const request = () => this.queue.add(async () => await this.httpRequest(pieceIndex, offset, length, (err, data) => {
+        if (err || data?.length !== length) return request()
         callback(err, data)
-      })
+      }))
+      request()
     })
   }
 
-  httpRequest (pieceIndex, offset, length, cb) {
+  async httpRequest (pieceIndex, offset, length, cb) {
     const pieceOffset = pieceIndex * this._torrent.pieceLength
-    const rangeStart = pieceOffset + offset /* offset within whole torrent */
+    const rangeStart = pieceOffset + offset
     const rangeEnd = rangeStart + length - 1
-
-    // Web seed URL format:
-    // For single-file torrents, make HTTP range requests directly to the web seed URL
-    // For multi-file torrents, add the torrent folder and file name to the URL
     const files = this._torrent.files
     let requests
     if (files.length <= 1) {
@@ -97,23 +120,19 @@ class WebConn extends Wire {
         return cb(new Error('Could not find file corresponding to web seed range request'))
       }
 
-      requests = requestedFiles.map(requestedFile => {
-        const fileEnd = requestedFile.offset + requestedFile.length - 1
+      requests = requestedFiles.map(file => {
+        const fileEnd = file.offset + file.length - 1
         const url = this.url +
-          (this.url[this.url.length - 1] === '/' ? '' : '/') +
-          requestedFile.path
+        (this.url[this.url.length - 1] === '/' ? '' : '/') +
+        file.path
         return {
           url,
-          fileOffsetInRange: Math.max(requestedFile.offset - rangeStart, 0),
-          start: Math.max(rangeStart - requestedFile.offset, 0),
-          end: Math.min(fileEnd, rangeEnd - requestedFile.offset)
+          fileOffsetInRange: Math.max(file.offset - rangeStart, 0),
+          start: Math.max(rangeStart - file.offset, 0),
+          end: Math.min(fileEnd, rangeEnd - file.offset)
         }
       })
     }
-
-    // Now make all the HTTP requests we need in order to load this piece
-    // Usually that's one requests, but sometimes it will be multiple
-    // Send requests in parallel and wait for them all to come back
     let numRequestsSucceeded = 0
     let hasError = false
 
@@ -122,92 +141,82 @@ class WebConn extends Wire {
       ret = Buffer.alloc(length)
     }
 
-    requests.forEach(request => {
-      const url = request.url
-      const start = request.start
-      const end = request.end
-      debug(
-        'Requesting url=%s pieceIndex=%d offset=%d length=%d start=%d end=%d',
-        url, pieceIndex, offset, length, start, end
-      )
-      const opts = {
-        url,
-        method: 'GET',
-        headers: {
-          'user-agent': `WebTorrent/${VERSION} (https://webtorrent.io)`,
-          range: `bytes=${start}-${end}`
-        },
-        timeout: SOCKET_TIMEOUT
-      }
+    let { res, reader, endRange, setSize, ctrl } = this.lastRequest
+    for await (const request of requests) {
+      const { url, start, end } = request
       function onResponse (res, data) {
-        if (res.statusCode < 200 || res.statusCode >= 300) {
+        if (!res || res.status < 200 || res.status >= 300) {
           if (hasError) return
           hasError = true
-          return cb(new Error(`Unexpected HTTP status code ${res.statusCode}`))
+          return cb(new Error(`Unexpected HTTP status code ${res?.status}`))
         }
-        debug('Got data of length %d', data.length)
-
         if (requests.length === 1) {
-          // Common case: fetch piece in a single HTTP request, return directly
           cb(null, data)
         } else {
-          // Rare case: reconstruct multiple HTTP requests across 2+ files into one
-          // piece buffer
           data.copy(ret, request.fileOffsetInRange)
           if (++numRequestsSucceeded === requests.length) {
             cb(null, ret)
           }
         }
       }
-      get.concat(opts, (err, res, data) => {
-        if (hasError) return
-        if (err) {
-          // Browsers allow HTTP redirects for simple cross-origin
-          // requests but not for requests that require preflight.
-          // Use a simple request to unravel any redirects and get the
-          // final URL.  Retry the original request with the new URL if
-          // it's different.
-          //
-          // This test is imperfect but it's simple and good for common
-          // cases.  It catches all cross-origin cases but matches a few
-          // same-origin cases too.
-          if (typeof window === 'undefined' || url.startsWith(`${window.location.origin}/`)) {
-            hasError = true
-            return cb(err)
-          }
+      if (endRange !== start - 1 || ctrl?.signal?.aborted) {
+        async function * read (reader) { // <3 Endless
+          let buffered = []
+          let bufferedBytes = 0
+          let done = false
+          let size = 512
+          const setSize = x => { size = x }
+          yield setSize
 
-          return get.head(url, (errHead, res) => {
-            if (hasError) return
-            if (errHead) {
-              hasError = true
-              return cb(errHead)
-            }
-            if (res.statusCode < 200 || res.statusCode >= 300) {
-              hasError = true
-              return cb(new Error(`Unexpected HTTP status code ${res.statusCode}`))
-            }
-            if (res.url === url) {
-              hasError = true
-              return cb(err)
-            }
+          while (!done) {
+            const it = await reader.read()
+            done = it.done
+            if (done) {
+              yield concat(buffered, bufferedBytes)
+              return
+            } else {
+              bufferedBytes += it.value.byteLength
+              buffered.push(it.value)
 
-            opts.url = res.url
-            get.concat(opts, (err, res, data) => {
-              if (hasError) return
-              if (err) {
-                hasError = true
-                return cb(err)
+              while (bufferedBytes >= size) {
+                const b = concat(buffered)
+                bufferedBytes -= size
+                yield b.slice(0, size)
+                buffered = [b.slice(size, b.length)]
               }
-              onResponse(res, data)
-            })
-          })
+            }
+          }
         }
-        onResponse(res, data)
-      })
-    })
+        if (ctrl) ctrl.abort()
+        ctrl = new AbortController()
+        await this.sleep
+        try {
+          res = await fetch(url, {
+            headers: {
+              range: `bytes=${start}-`,
+              'user-agent': `WebTorrent/${VERSION} (https://webtorrent.io)`
+            },
+            signal: ctrl.signal
+          })
+        } catch (e) {
+          this.sleep = sleep(500)
+          onResponse()
+          throw e
+        }
+        this.sleep = sleep(500)
+        reader = read(res.body.getReader(), 1)
+        setSize = (await reader.next()).value // lazy, but 1st yield is callback x)
+      }
+      endRange = end
+      setSize(end - start + 1)
+      onResponse(res, (await reader.next()).value || new Uint8Array())
+    }
+    this.lastRequest = { res, reader, endRange, setSize, ctrl }
   }
 
   destroy () {
+    this.lastRequest?.ctrl?.abort()
+    this.queue.destroy()
     super.destroy()
     this._torrent = null
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "load-ip-set": false,
     "net": false,
     "os": false,
+    "node-fetch": false,
     "ut_pex": false
   },
   "browserify": {
@@ -56,6 +57,7 @@
     "memory-chunk-store": "^1.3.5",
     "mime": "^2.5.2",
     "multistream": "^4.1.0",
+    "node-fetch": "^2.6.2",
     "package-json-versionify": "^1.0.4",
     "parse-torrent": "^9.1.4",
     "pump": "^3.0.0",


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
This is a very rough and quick draft on improving the speeds and performance of webseeds.

Changed webseeds to use a single linear request which removes latency introduced by spamming requests per piece, improves max speeds and performance greatly. This also helps if the webseed is hosted on some API storage which limits the HTTP request queries to say 1 per second. [google drive].

Implements a queue, since WT request multiple pieces at a time, if any of the pieces are out of order, the old request will be aborted and a new one will init.

**Is there anything you'd like reviewers to focus on?**
Currently if there's a single poor health peer in the swarm, he'll create partial pieces, causing requests to abort since it requests multiple parts of the same piece with offsets out of order, there are a few ways of solving this:
- ignore offsetted piece requests, cache last requested piece and slice that piece [bad solution]
- ignore poor health peers in the swarm
- don't treat the webseed as a peer but a data store [not BEP compliant]
- only request full pieces from webseeds, no partial pieces

How to solve this?

Known issues:
- the webseed will keep downloading data even if webtorrent looses interest in it, because we can't control or pause data downloading from the browser [oops!], this could be solved by requesting only say max 10 pieces at a time, or aborting the request after the webseed is inactive for long enough.
- doesn't work on node just yet [other issues to fix first]
- performance drops when a poor health peer joins the swarm
- fetch errors on abort, no matter what try catch is used [woooo browsers]
- sometimes the request pieces don't match... for some reason... which makes webtorrent loose interest in the webseed, so I just re-request them again x), this however breaks the queue [TODO]