### PR TITLE
feat: add reqq field support

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1464,7 +1464,8 @@ class Torrent extends EventEmitter {
             piece = self._rarityMap.getRarestPiece(filter)
             if (piece < 0) break
 
-            while (self._request(wire, piece, self._critical[piece] || hotswap)) {
+            while (self._request(wire, piece, self._critical[piece] || hotswap) &&
+              wire.requests.length < maxOutstandingRequests) {
               // body intentionally empty
               // request all non-reserved blocks in this piece
             }
@@ -1482,7 +1483,8 @@ class Torrent extends EventEmitter {
           for (piece = next.from + next.offset; piece <= next.to; piece++) {
             if (!wire.peerPieces.get(piece) || !rank(piece)) continue
 
-            while (self._request(wire, piece, self._critical[piece] || hotswap)) {
+            while (self._request(wire, piece, self._critical[piece] || hotswap) &&
+              wire.requests.length < maxOutstandingRequests) {
               // body intentionally empty
               // request all non-reserved blocks in piece
             }
@@ -1920,7 +1922,17 @@ class Torrent extends EventEmitter {
 }
 
 function getBlockPipelineLength (wire, duration) {
-  return 2 + Math.ceil(duration * wire.downloadSpeed() / Piece.BLOCK_LENGTH)
+  let length = 2 + Math.ceil(duration * wire.downloadSpeed() / Piece.BLOCK_LENGTH)
+
+  // Honor reqq (maximum number of outstanding request messages) if specified by peer
+  if (wire.peerExtendedHandshake) {
+    const reqq = wire.peerExtendedHandshake.reqq
+    if (typeof reqq === 'number' && reqq > 0) {
+      length = Math.min(length, reqq)
+    }
+  }
+
+  return length
 }
 
 function getPiecePipelineLength (wire, duration, pieceLength) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR adds support for the `reqq` field in the enhanced header, as described in [BEP 10](https://www.bittorrent.org/beps/bep_0010.html). The `reqq` field allows a client to specify the maximum number of outstanding requests it supports.

**Which issue (if any) does this pull request address?**

It implements the last part of https://github.com/webtorrent/webtorrent/issues/1995.

**Is there anything you'd like reviewers to focus on?**

Honoring the field properly requires to change the logic in `_updateWire()` to make `maxOutstandingRequests` a hard limit.