### PR TITLE
fix: web seed request URLs

### DIFF
--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -102,7 +102,7 @@ class WebConn extends Wire {
         const fileEnd = requestedFile.offset + requestedFile.length - 1
         const url = this.url +
           (this.url[this.url.length - 1] === '/' ? '' : '/') +
-          requestedFile.path
+          requestedFile.path.replace(this._torrent.path, "")
         return {
           url,
           fileOffsetInRange: Math.max(requestedFile.offset - rangeStart, 0),

--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -102,7 +102,7 @@ class WebConn extends Wire {
         const fileEnd = requestedFile.offset + requestedFile.length - 1
         const url = this.url +
           (this.url[this.url.length - 1] === '/' ? '' : '/') +
-          requestedFile.path.replace(this._torrent.path, "")
+          requestedFile.path.replace(this._torrent.path, '')
         return {
           url,
           fileOffsetInRange: Math.max(requestedFile.offset - rangeStart, 0),


### PR DESCRIPTION
When adding a multi torrent file (not magnet link) which has only web seeds, the torrent fails to download because webtorrent seems to try to call the wrong URL.

Suppose that we are using the default download path of `/tmp/webtorrent`, and we have a web seed at `https://some-s3-bucket.s3.amazonaws.com/my-torrent` where `my-torrent` contains some nested directory structure like this:

```
my-torrent/
    file1.txt
    file2/
        file2.txt
```

Webtorrent will attempt to fetch the following URLs:

```
https://some-s3-bucket.s3.amazonaws.com/my-torrent//tmp/webtorrent/my-torrent/file1.txt
https://some-s3-bucket.s3.amazonaws.com/my-torrent//tmp/webtorrent/my-torrent/file2/file2.txt
```

This is obviously incorrect, but perhaps I'm doing something wrong to cause this. I dug through the code, and it seems that `fs-chunk-store` is [modifying `file.path`](https://github.com/webtorrent/fs-chunk-store/blob/master/index.js#L48) when the [chunk store is created](https://github.com/webtorrent/webtorrent/blob/master/lib/torrent.js#L485). Stripping off the temp path fixes this issue and the download progresses as expected.

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[-] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
