### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ class WebTorrent extends EventEmitter {
           }
           port.postMessage(chunk)
           if (!chunk) cleanup()
-          if (!this.workerKeepAliveInterval) this.workerKeepAliveInterval = setInterval(() => fetch(`${this.serviceWorker.scriptURL.substr(0, this.serviceWorker.scriptURL.lastIndexOf('/') + 1).slice(window.location.origin.length)}webtorrent/keepalive/`), keepAliveTime)
+          if (!this.workerKeepAliveInterval) this.workerKeepAliveInterval = setInterval(() => fetch(`${this.serviceWorker.scriptURL.slice(0, this.serviceWorker.scriptURL.lastIndexOf('/') + 1).slice(window.location.origin.length)}webtorrent/keepalive/`), keepAliveTime)
         } else {
           cleanup()
         }

--- a/lib/file.js
+++ b/lib/file.js
@@ -206,7 +206,7 @@ class File extends EventEmitter {
     if (typeof window === 'undefined') throw new Error('browser-only method')
     if (!this._serviceWorker) throw new Error('No worker registered')
     if (this._serviceWorker.state !== 'activated') throw new Error('Worker isn\'t activated')
-    const workerPath = this._serviceWorker.scriptURL.substr(0, this._serviceWorker.scriptURL.lastIndexOf('/') + 1).slice(window.location.origin.length)
+    const workerPath = this._serviceWorker.scriptURL.slice(0, this._serviceWorker.scriptURL.lastIndexOf('/') + 1).slice(window.location.origin.length)
     const url = `${workerPath}webtorrent/${this._torrent.infoHash}/${encodeURI(this.path)}`
     cb(null, url)
   }
@@ -215,7 +215,7 @@ class File extends EventEmitter {
     if (typeof window === 'undefined') throw new Error('browser-only method')
     if (!this._serviceWorker) throw new Error('No worker registered')
     if (this._serviceWorker.state !== 'activated') throw new Error('Worker isn\'t activated')
-    const workerPath = this._serviceWorker.scriptURL.substr(0, this._serviceWorker.scriptURL.lastIndexOf('/') + 1).slice(window.location.origin.length)
+    const workerPath = this._serviceWorker.scriptURL.slice(0, this._serviceWorker.scriptURL.lastIndexOf('/') + 1).slice(window.location.origin.length)
     elem.src = `${workerPath}webtorrent/${this._torrent.infoHash}/${encodeURI(this.path)}`
     cb(null, elem)
   }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
