### PR TITLE
Update torrent.js

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -291,7 +291,7 @@ class Torrent extends EventEmitter {
   _onListening () {
     if (this.destroyed) return
 
-    if (this.info) {
+    if (this.metadata) {
       // if full metadata was included in initial torrent id, use it immediately. Otherwise,
       // wait for torrent-discovery to find peers and ut_metadata to get the metadata.
       this._onMetadata(this)


### PR DESCRIPTION
As far as I can tell, this line is simply incorrect, since there's nothing that ever assigns a value to `this.info` and it makes much more sense that the intention is to check whether the metadata has already been fetched.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
`this.info` isn't a thing. `this.metadata` however is.

**Which issue (if any) does this pull request address?**
It's part of adressing the issue that it takes a long time for downloading to start. As it is right now the code will never be able to skip the step of connecting to peers to get metadata, even if metadata is supplied.

**Is there anything you'd like reviewers to focus on?**
torrent.js is in pretty desperate need of some love and care. This was just the first thing I found that I'm 100% sure is not working as intended, but there's definitely more issues in there.