### PR TITLE
docs: replace `git.io` link with the actual URL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
     #  uses: github/codeql-action/autobuild@v1
 
     # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+    # 📚 https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -163,7 +163,7 @@ There's also a list of WebTorrent-powered alternatives to centralized services h
 [dropclickpaste]: http://dropclickpaste.com/
 [filemap]: https://filemap.xyz
 [wtgc]: https://wtgc.firebaseapp.com
-[wtgc-source]: https://git.io/wtgc
+[wtgc-source]: https://github.com/FluorescentHallucinogen/webtorrent-googlecast
 [codedump]: http://ronsoros.github.io
 [codedump-source]: https://github.com/ronsoros/ronsoros.github.io/blob/master/index.html
 [lunik-torrent]: https://tcloud-lunik.herokuapp.com


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Replace git.io inside the README with its original URL.
