### PR TITLE
chore(docs): add Niwder web platform

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -111,6 +111,7 @@ WebTorrent is still pretty new, but it's already being used in cool ways:
 - **[atorable-react][atorable-react]** -  React component that processes a Webtorrent magnet uri for viewing or other custom uses. ([source code][atorable-react-source])
 - **[Iris][iris-messenger]** - Decentralized social networking application. ([source code][iris-messenger-source])
 - **[TorQuiX][TorQuiX]** - Web client for webtorrent-hybrid (Works in docker, in the future will be Android/Windows/Mac/Linux release). ([source code][TorQuiX-source]) 
+- **[Niwder][Niwder]** - Web based platform to transfer torrents to Mega.nz and Google Drive on the cloud. ([source code][Niwder-source])
 - ***Your app here – [Send a pull request][pr] with your URL!***
 <!-- - **[PeerCloud][peercloud]** - Serverless websites via WebTorrent ([source code][peercloud-source]) -->
 <!-- - **[Niagara][niagara]** - Video player webtorrent with subtitles (zipped .srt(s)) -->
@@ -204,6 +205,8 @@ There's also a list of WebTorrent-powered alternatives to centralized services h
 [iris-messenger-source]: https://github.com/irislib/iris-messenger
 [TorQuiX]: https://hub.docker.com/r/mauromazzocchetti/webtorrent-express-api
 [TorQuiX-source]: https://github.com/drakonkat/webtorrent-express-api
+[Niwder]: https://niwder.niweera.gq
+[Niwder-source]: https://github.com/Niweera/niwder
 
 ## How does WebTorrent work?
 


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Added Niwder web platform to the WebTorrent FAQ document.

[Niwder](https://niwder.niweera.gq) is a web-based platform that provides the facility to transfer torrents to Google Drive and Mega.nz storage on the cloud. 

The following is a demo of the system.

![demo-video](https://raw.githubusercontent.com/Niweera/niwder/main/src/helpers/torrents-download-demo.gif)

The usage and system architecture can be viewed from [here](https://github.com/Niweera/niwder#readme).

Essentially, Niwder is a system in three parts where,

1. [Niwder-API](https://github.com/Niweera/niwder-api) ([API Documentation](https://niwder-api.niweera.gq/api/docs/))
2. [Niwder-Worker](https://github.com/Niweera/niwder-api/tree/main/src/worker)
3. [Niwder-UI](https://github.com/Niweera/niwder)

**Which issue (if any) does this pull request address?**
N/A

**Is there anything you'd like reviewers to focus on?**
N/A
