### PR TITLE
feat: Unifiy HTTP server and SW renderer.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -299,7 +299,6 @@ Here is a user example for browser:
 const client = new WebTorrent()
 const magnetURI = 'magnet: ...'
 const player = document.querySelector('video')
-const scope = './'
 
 function download (instance) {
   client.add(magnetURI, torrent => {
@@ -310,7 +309,7 @@ function download (instance) {
     // access individual torrents at /webtorrent/<infoHash> where infoHash is the hash of the torrent
   })
 }
-navigator.serviceWorker.register('./sw.min.js', { scope }).then(reg => {
+navigator.serviceWorker.register('./sw.min.js', { scope: './' }).then(reg => {
   const worker = reg.active || reg.waiting || reg.installing
   function checkState (worker) {
     return worker.state === 'activated' && download(client.createServer({ controller: reg }))

--- a/docs/api.md
+++ b/docs/api.md
@@ -273,22 +273,22 @@ Here is a usage example for Node.js:
 const client = new WebTorrent()
 const magnetURI = 'magnet: ...'
 
-client.add(magnetURI, function (torrent) {
+const instance = client.createServer()
+instance.server.listen(0) // start the server listening to a port
+// 0 automatically finds an open port instead of forcing a potentially used one
+client.add(magnetURI, torrent => {
   // create HTTP server for this torrent
-  const instance = torrent.createServer()
-  instance.server.listen(port) // start the server listening to a port
 
   const url = torrent.files[0].getStreamURL()
   console.log(url)
-
   // visit http://localhost:<port>/webtorrent/ to see a list of torrents
 
   // access individual torrents at http://localhost:<port>/webtorrent/<infoHash> where infoHash is the hash of the torrent
-
-  // later, cleanup...
-  instance.close()
-  client.destroy()
 })
+
+// later, cleanup...
+instance.close()
+client.destroy()
 ```
 
 In browser needs either [this worker](https://github.com/webtorrent/webtorrent/blob/master/sw.min.js) to be used, or have [this functionality](https://github.com/webtorrent/webtorrent/blob/master/lib/worker.js) implemented.
@@ -305,14 +305,9 @@ function download (instance) {
   client.add(magnetURI, torrent => {
     const url = torrent.files[0].getStreamURL()
     console.log(url)
-
     // visit <origin>/webtorrent/ to see a list of torrents, where origin is the worker registration scope.
 
     // access individual torrents at /webtorrent/<infoHash> where infoHash is the hash of the torrent
-
-    // later, cleanup...
-    instance.close()
-    client.destroy()
   })
 }
 navigator.serviceWorker.register('./sw.min.js', { scope }).then(reg => {
@@ -324,6 +319,10 @@ navigator.serviceWorker.register('./sw.min.js', { scope }).then(reg => {
     worker.addEventListener('statechange', ({ target }) => checkState(target))
   }
 })
+
+// later, cleanup...
+client._server.close()
+client.destroy()
 ```
 # Torrent API
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -14,7 +14,6 @@ import WebTorrent from 'webtorrent'
 const client = new WebTorrent()
 const torrentId = 'magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fsintel.torrent'
 const player = document.querySelector('video')
-const scope = './'
 
 function download () {
   client.add(torrentId, torrent => {
@@ -31,7 +30,7 @@ function download () {
     console.log('Ready to play!')
   })
 }
-navigator.serviceWorker.register('./sw.min.js', { scope }).then(reg => {
+navigator.serviceWorker.register('./sw.min.js', { scope: './' }).then(reg => {
   const worker = reg.active || reg.waiting || reg.installing
   function checkState (worker) {
     return worker.state === 'activated' && client.createServer({ controller: reg }) && download()
@@ -85,7 +84,6 @@ Code example:
 const client = new WebTorrent()
 const torrentId = 'magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fsintel.torrent'
 const player = document.querySelector('video')
-const scope = './'
 
 function download () {
   client.add(torrentId, torrent => {
@@ -97,7 +95,7 @@ function download () {
     console.log('Ready to play!')
   })
 }
-navigator.serviceWorker.register('./sw.min.js', { scope }).then(reg => {
+navigator.serviceWorker.register('./sw.min.js', { scope: './' }).then(reg => {
   const worker = reg.active || reg.waiting || reg.installing
   function checkState (worker) {
     return worker.state === 'activated' && client.createServer({ controller: reg }) && download()

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -12,8 +12,9 @@ Code example:
 import WebTorrent from 'webtorrent'
 
 const client = new WebTorrent()
-const torrentId = "magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fsintel.torrent"
+const torrentId = 'magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fsintel.torrent'
 const player = document.querySelector('video')
+const scope = './'
 
 function download () {
   client.add(torrentId, torrent => {
@@ -26,15 +27,14 @@ function download () {
       }
     })
     // Stream to a <video> element by providing an the DOM element
-    file.streamTo(player, () => {
-      console.log('Ready to play!')
-    })
-  }
+    file.streamTo(player)
+    console.log('Ready to play!')
+  })
 }
-navigator.serviceWorker.register('sw.min.js', { scope }).then(reg => {
+navigator.serviceWorker.register('./sw.min.js', { scope }).then(reg => {
   const worker = reg.active || reg.waiting || reg.installing
   function checkState (worker) {
-    return worker.state === 'activated' && client.loadWorker(worker, download)
+    return worker.state === 'activated' && client.createServer({ controller: reg }) && download()
   }
   if (!checkState(worker)) {
     worker.addEventListener('statechange', ({ target }) => checkState(target))
@@ -82,30 +82,30 @@ Code example:
   <body>
     <video id="video-container" class="video-js" data-setup="{}" controls="true"></video>
     <script>
-      const client = new WebTorrent()
-      const torrentId = "magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fsintel.torrent"
-      const player = document.querySelector("video#video-container_html5_api")
+const client = new WebTorrent()
+const torrentId = 'magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fsintel.torrent'
+const player = document.querySelector('video')
+const scope = './'
 
-      function download () {
-        client.add(torrentId, torrent => {
-          // Torrents can contain many files. Let's use the .mp4 file
-          const file = torrent.files.find(file => file.name.endsWith('.mp4'))
-      
-          // Stream to a <video> element by providing an the DOM element
-          file.streamTo(player, () => {
-            console.log('Ready to play!')
-          })
-        })
-      }
-      navigator.serviceWorker.register('sw.min.js', { scope }).then(reg => {
-        const worker = reg.active || reg.waiting || reg.installing
-        function checkState (worker) {
-          return worker.state === 'activated' && client.loadWorker(worker, download)
-        }
-        if (!checkState(worker)) {
-          worker.addEventListener('statechange', ({ target }) => checkState(target))
-        }
-      })
+function download () {
+  client.add(torrentId, torrent => {
+    // Torrents can contain many files. Let's use the .mp4 file
+    const file = torrent.files.find(file => file.name.endsWith('.mp4'))
+
+    // Stream to a <video> element by providing an the DOM element
+    file.streamTo(player)
+    console.log('Ready to play!')
+  })
+}
+navigator.serviceWorker.register('./sw.min.js', { scope }).then(reg => {
+  const worker = reg.active || reg.waiting || reg.installing
+  function checkState (worker) {
+    return worker.state === 'activated' && client.createServer({ controller: reg }) && download()
+  }
+  if (!checkState(worker)) {
+    worker.addEventListener('statechange', ({ target }) => checkState(target))
+  }
+})
     </script>
   </body>
 </html>

--- a/lib/file.js
+++ b/lib/file.js
@@ -35,7 +35,7 @@ class File extends EventEmitter {
       this.emit('done')
     }
 
-    this._serviceWorker = torrent.client.serviceWorker
+    this._server = torrent.client._server
   }
 
   get downloaded () {
@@ -190,22 +190,15 @@ class File extends EventEmitter {
     return [res, pipe || stream, pipe && stream]
   }
 
-  getStreamURL (cb = () => {}) {
-    if (typeof window === 'undefined') throw new Error('browser-only method')
-    if (!this._serviceWorker) throw new Error('No worker registered')
-    if (this._serviceWorker.state !== 'activated') throw new Error('Worker isn\'t activated')
-    const workerPath = this._serviceWorker.scriptURL.slice(0, this._serviceWorker.scriptURL.lastIndexOf('/') + 1).slice(window.location.origin.length)
-    const url = `${workerPath}webtorrent/${this._torrent.infoHash}/${encodeURI(this.path)}`
-    cb(null, url)
+  getStreamURL () {
+    if (!this._server) throw new Error('No server created')
+    const url = `${this._server.pathname}/${this._torrent.infoHash}/${encodeURI(this.path)}`
+    return url
   }
 
-  streamTo (elem, cb = () => {}) {
-    if (typeof window === 'undefined') throw new Error('browser-only method')
-    if (!this._serviceWorker) throw new Error('No worker registered')
-    if (this._serviceWorker.state !== 'activated') throw new Error('Worker isn\'t activated')
-    const workerPath = this._serviceWorker.scriptURL.slice(0, this._serviceWorker.scriptURL.lastIndexOf('/') + 1).slice(window.location.origin.length)
-    elem.src = `${workerPath}webtorrent/${this._torrent.infoHash}/${encodeURI(this.path)}`
-    cb(null, elem)
+  streamTo (elem) {
+    elem.src = this.getStreamURL()
+    return elem
   }
 
   includes (piece) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,247 +4,393 @@ const mime = require('mime')
 const pump = require('pump')
 const rangeParser = require('range-parser')
 const queueMicrotask = require('queue-microtask')
+const { Readable } = require('stream')
 
-function Server (torrent, opts = {}) {
-  const server = http.createServer()
-  if (!opts.origin) opts.origin = '*' // allow all origins by default
+const keepAliveTime = 20000
 
-  const sockets = new Set()
-  const pendingReady = new Set()
-  let closed = false
-  const _listen = server.listen
-  const _close = server.close
-
-  server.listen = (...args) => {
-    closed = false
-    server.on('connection', onConnection)
-    server.on('request', onRequest)
-    return _listen.apply(server, args)
+class ServerBase {
+  constructor (client, opts = {}) {
+    this.client = client
+    if (!opts.origin) opts.origin = '*' // allow all origins by default
+    this.opts = opts
   }
 
-  server.close = cb => {
-    closed = true
-    server.removeListener('connection', onConnection)
-    server.removeListener('request', onRequest)
-    pendingReady.forEach(onReady => {
-      torrent.removeListener('ready', onReady)
-    })
-    pendingReady.clear()
-    _close.call(server, cb)
+  static serveIndexPage (res, torrents) {
+    const listHtml = torrents
+      .map(torrent => (
+      `<li>
+        <a href="${escapeHtml(torrent.infoHash)}">
+          ${escapeHtml(torrent.name)}
+        </a>
+        (${escapeHtml(torrent.length)} bytes)
+      </li>`
+      ))
+      .join('<br>')
+
+
+    res.status = 200
+    res.headers['Content-Type'] = 'text/html'
+    res.body = getPageHTML(
+      'WebTorrent',
+        `<h1>WebTorrent</h1>
+         <ol>${listHtml}</ol>`
+    )
+
+    return res
   }
 
-  server.destroy = cb => {
-    sockets.forEach(socket => {
-      socket.destroy()
-    })
-
-    // Only call `server.close` if user has not called it already
-    if (!cb) cb = () => {}
-    if (closed) queueMicrotask(cb)
-    else server.close(cb)
-    torrent = null
-  }
-
-  function isOriginAllowed (req) {
+  isOriginAllowed (req) {
     // When `origin` option is `false`, deny all cross-origin requests
-    if (opts.origin === false) return false
-
-    // Requests without an 'Origin' header are not actually cross-origin, so just
-    // deny them
-    if (req.headers.origin == null) return false
+    if (this.opts.origin === false) return false
 
     // The user allowed all origins
-    if (opts.origin === '*') return true
+    if (this.opts.origin === '*') return true
 
     // Allow requests where the 'Origin' header matches the `opts.origin` setting
-    return req.headers.origin === opts.origin
+    return req.headers.origin === this.opts.origin
   }
 
-  function onConnection (socket) {
-    socket.setTimeout(36000000)
-    sockets.add(socket)
-    socket.once('close', () => {
-      sockets.delete(socket)
-    })
+  static serveMethodNotAllowed (res) {
+    res.status = 405
+    res.headers['Content-Type'] = 'text/html'
+
+    res.body = getPageHTML(
+      '405 - Method Not Allowed',
+      '<h1>405 - Method Not Allowed</h1>'
+    )
+
+    return res
   }
 
-  function onRequest (req, res) {
-    // If a 'hostname' string is specified, deny requests with a 'Host'
-    // header that does not match the origin of the torrent server to prevent
-    // DNS rebinding attacks.
-    if (opts.hostname && req.headers.host !== `${opts.hostname}:${server.address().port}`) {
-      return req.destroy()
+  static serve404Page (res) {
+    res.status = 404
+    res.headers['Content-Type'] = 'text/html'
+
+    res.body = getPageHTML(
+      '404 - Not Found',
+      '<h1>404 - Not Found</h1>'
+    )
+    return res
+  }
+
+  static serveTorrentPage (torrent, res) {
+    const listHtml = torrent.files
+      .map(file => (
+    `<li>
+      <a href="${torrent.infoHash}/${escapeHtml(file.path)}">
+        ${escapeHtml(file.path)}
+      </a>
+      (${escapeHtml(file.length)} bytes)
+    </li>`
+      ))
+      .join('<br>')
+
+
+    res.status = 200
+    res.headers['Content-Type'] = 'text/html'
+
+    res.body = getPageHTML(
+        `${escapeHtml(torrent.name)} - WebTorrent`,
+        `<h1>${escapeHtml(torrent.name)}</h1>
+        <ol>${listHtml}</ol>`
+    )
+
+    return res
+  }
+
+  static serveOptionsRequest (req, res) {
+    res.status = 204 // no content
+    res.headers['Access-Control-Max-Age'] = '600'
+    res.headers['Access-Control-Allow-Methods'] = 'GET,HEAD'
+
+
+    if (req.headers['access-control-request-headers']) {
+      res.headers['Access-Control-Allow-Headers'] = req.headers['access-control-request-headers']
+    }
+    return res
+  }
+
+  static serveFile (file, req, res) {
+    res.status = 200
+
+    // Disable caching as data is local anyways
+    res.headers.Expires = '0'
+    res.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate, max-age=0'
+    // Support range-requests
+    res.headers['Accept-Ranges'] = 'bytes'
+    res.headers['Content-Type'] = mime.getType(file.name) || 'application/octet-stream'
+    // Support DLNA streaming
+    res.headers['transferMode.dlna.org'] = 'Streaming'
+    res.headers['contentFeatures.dlna.org'] = 'DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=01700000000000000000000000000000'
+
+    // Force the browser to download the file if if it's opened in a new tab
+    // Set name of file (for "Save Page As..." dialog)
+    if (req.destination === 'document') {
+      res.headers['Content-Type'] = 'application/octet-stream'
+      res.headers['Content-Disposition'] = `attachment; filename*=UTF-8''${encodeRFC5987(file.name)}`
+      res.body = 'DOWNLOAD'
+    } else {
+      res.headers['Content-Disposition'] = `inline; filename*=UTF-8''${encodeRFC5987(file.name)}`
     }
 
-    const pathname = new URL(req.url, 'http://example.com').pathname
+    // `rangeParser` returns an array of ranges, or an error code (number) if
+    // there was an error parsing the range.
+    let range = rangeParser(file.length, req.headers.range || '')
+
+    if (Array.isArray(range)) {
+      res.status = 206 // indicates that range-request was understood
+
+      // no support for multi-range request, just use the first range
+      range = range[0]
+
+      res.headers['Content-Range'] = `bytes ${range.start}-${range.end}/${file.length}`
+
+      res.headers['Content-Length'] = range.end - range.start + 1
+    } else {
+      res.statusCode = 200
+      range = null
+      res.headers['Content-Length'] = file.length
+    }
+
+
+    const stream = req.method === 'GET' && file.createReadStream(range)
+
+    let pipe = null
+    if (stream) {
+      file.emit('stream', { stream, req, file }, target => {
+        pipe = pump(stream, target)
+      })
+    }
+    res.body = pipe || stream
+    return res
+  }
+
+  onRequest (req, cb) {
+    let pathname = new URL(req.url, 'http://example.com').pathname
+    pathname = pathname.slice(pathname.indexOf(this.pathname) + this.pathname.length + 1)
+
+    const res = {
+      headers: {
+        // Prevent browser mime-type sniffing
+        'X-Content-Type-Options': 'nosniff',
+        // Defense-in-depth: Set a strict Content Security Policy to mitigate XSS
+        'Content-Security-Policy': "base-uri 'none'; frame-ancestors 'none'; form-action 'none';"
+      }
+    }
 
     // Allow cross-origin requests (CORS)
-    if (isOriginAllowed(req)) {
-      res.setHeader('Access-Control-Allow-Origin', req.headers.origin)
+    if (this.isOriginAllowed(req)) {
+      res.headers['Access-Control-Allow-Origin'] = this.opts.origin === '*' ? '*' : req.headers.origin
     }
 
-    // Prevent browser mime-type sniffing
-    res.setHeader('X-Content-Type-Options', 'nosniff')
-
-    // Defense-in-depth: Set a strict Content Security Policy to mitigate XSS
-    res.setHeader('Content-Security-Policy', "base-uri 'none'; default-src 'none'; frame-ancestors 'none'; form-action 'none';")
-
-    if (pathname === '/favicon.ico') {
-      return serve404Page()
+    if (pathname === 'favicon.ico') {
+      return cb(ServerBase.serve404Page(res))
     }
 
     // Allow CORS requests to specify arbitrary headers, e.g. 'Range',
     // by responding to the OPTIONS preflight request with the specified
     // origin and requested headers.
     if (req.method === 'OPTIONS') {
-      if (isOriginAllowed(req)) return serveOptionsRequest()
-      else return serveMethodNotAllowed()
+      if (this.isOriginAllowed(req)) return cb(ServerBase.serveOptionsRequest(req, res))
+      else return cb(ServerBase.serveMethodNotAllowed(res))
+    }
+
+    const onReady = () => {
+      this.pendingReady.delete(onReady)
+      cb(handleRequest())
+    }
+
+    const handleRequest = () => {
+      if (pathname === '') {
+        return ServerBase.serveIndexPage(res, this.client.torrents)
+      }
+
+      let [infoHash, ...filePath] = pathname.split('/')
+      filePath = decodeURI(filePath.join('/'))
+
+      const torrent = this.client.get(infoHash)
+      if (!infoHash || !torrent) {
+        return ServerBase.serve404Page(res)
+      }
+
+      if (!filePath) {
+        return ServerBase.serveTorrentPage(torrent, res)
+      }
+
+      const file = torrent.files.find(file => file.path.replace(/\\/, '/') === filePath)
+      if (!file) {
+        return ServerBase.serve404Page(res)
+      }
+      return ServerBase.serveFile(file, req, res)
     }
 
     if (req.method === 'GET' || req.method === 'HEAD') {
-      if (torrent.ready) {
-        return handleRequest()
+      if (this.client.ready) {
+        return cb(handleRequest())
       } else {
-        pendingReady.add(onReady)
-        torrent.once('ready', onReady)
+        this.pendingReady.add(onReady)
+        this.client.once('ready', onReady)
         return
       }
     }
 
-    return serveMethodNotAllowed()
-
-    function serveOptionsRequest () {
-      res.statusCode = 204 // no content
-      res.setHeader('Access-Control-Max-Age', '600')
-      res.setHeader('Access-Control-Allow-Methods', 'GET,HEAD')
-
-      if (req.headers['access-control-request-headers']) {
-        res.setHeader(
-          'Access-Control-Allow-Headers',
-          req.headers['access-control-request-headers']
-        )
-      }
-      res.end()
-    }
-
-    function onReady () {
-      pendingReady.delete(onReady)
-      handleRequest()
-    }
-
-    function handleRequest () {
-      if (pathname === '/') {
-        return serveIndexPage()
-      }
-
-      const index = Number(pathname.split('/')[1])
-      if (Number.isNaN(index) || index >= torrent.files.length) {
-        return serve404Page()
-      }
-
-      const file = torrent.files[index]
-      serveFile(file)
-    }
-
-    function serveIndexPage () {
-      res.statusCode = 200
-      res.setHeader('Content-Type', 'text/html')
-
-      const listHtml = torrent.files
-        .map((file, i) => (
-          `<li>
-            <a
-              download="${escapeHtml(file.name)}"
-              href="${escapeHtml(i)}/${escapeHtml(file.name)}"
-            >
-              ${escapeHtml(file.path)}
-            </a>
-            (${escapeHtml(file.length)} bytes)
-          </li>`
-        ))
-        .join('<br>')
-
-      const html = getPageHTML(
-        `${escapeHtml(torrent.name)} - WebTorrent`,
-        `
-          <h1>${escapeHtml(torrent.name)}</h1>
-          <ol>${listHtml}</ol>
-        `
-      )
-      res.end(html)
-    }
-
-    function serve404Page () {
-      res.statusCode = 404
-      res.setHeader('Content-Type', 'text/html')
-
-      const html = getPageHTML(
-        '404 - Not Found',
-        '<h1>404 - Not Found</h1>'
-      )
-      res.end(html)
-    }
-
-    function serveFile (file) {
-      res.setHeader('Content-Type', mime.getType(file.name) || 'application/octet-stream')
-
-      // Support range-requests
-      res.setHeader('Accept-Ranges', 'bytes')
-
-      // Set name of file (for "Save Page As..." dialog)
-      res.setHeader(
-        'Content-Disposition',
-        `inline; filename*=UTF-8''${encodeRFC5987(file.name)}`
-      )
-
-      // Support DLNA streaming
-      res.setHeader('transferMode.dlna.org', 'Streaming')
-      res.setHeader(
-        'contentFeatures.dlna.org',
-        'DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=01700000000000000000000000000000'
-      )
-
-      // `rangeParser` returns an array of ranges, or an error code (number) if
-      // there was an error parsing the range.
-      let range = rangeParser(file.length, req.headers.range || '')
-
-      if (Array.isArray(range)) {
-        res.statusCode = 206 // indicates that range-request was understood
-
-        // no support for multi-range request, just use the first range
-        range = range[0]
-
-        res.setHeader(
-          'Content-Range',
-          `bytes ${range.start}-${range.end}/${file.length}`
-        )
-        res.setHeader('Content-Length', range.end - range.start + 1)
-      } else {
-        res.statusCode = 200
-        range = null
-        res.setHeader('Content-Length', file.length)
-      }
-
-      if (req.method === 'HEAD') {
-        return res.end()
-      }
-
-      pump(file.createReadStream(range), res)
-    }
-
-    function serveMethodNotAllowed () {
-      res.statusCode = 405
-      res.setHeader('Content-Type', 'text/html')
-      const html = getPageHTML(
-        '405 - Method Not Allowed',
-        '<h1>405 - Method Not Allowed</h1>'
-      )
-      res.end(html)
-    }
+    return ServerBase.serveMethodNotAllowed(res)
   }
 
-  return server
+  close (cb = () => {}) {
+    this.closed = true
+    this.pendingReady.forEach(onReady => {
+      this.client.removeListener('ready', onReady)
+    })
+    this.pendingReady.clear()
+    queueMicrotask(cb)
+  }
+
+  destroy (cb = () => {}) {
+    // Only call `server.close` if user has not called it already
+    if (this.closed) queueMicrotask(cb)
+    else this.close(cb)
+    this.client = null
+  }
 }
+
+class NodeServer extends ServerBase {
+  constructor (client, opts) {
+    super(client, opts)
+
+    this.server = http.createServer()
+
+    this.sockets = new Set()
+    this.pendingReady = new Set()
+    this.closed = false
+    this.pathname = opts?.pathname || '/webtorrent'
+  }
+
+  wrapRequest (req, res) {
+    // If a 'hostname' string is specified, deny requests with a 'Host'
+    // header that does not match the origin of the torrent server to prevent
+    // DNS rebinding attacks.
+    if (this.opts.hostname && req.headers.host !== `${this.opts.hostname}:${this.server.address().port}`) {
+      return req.destroy()
+    }
+
+    if (!new URL(req.url, 'http://example.com').pathname.startsWith(this.pathname)) {
+      return req.destroy()
+    }
+
+    this.onRequest(req, ({ status, headers, body }) => {
+      res.writeHead(status, headers)
+
+      if (body instanceof Readable) { // this is probably a bad way of checking? idk
+        pump(body, res)
+      } else {
+        res.end(body)
+      }
+    })
+  }
+
+  onConnection (socket) {
+    socket.setTimeout(36000000)
+    this.sockets.add(socket)
+    socket.once('close', () => {
+      this.sockets.delete(socket)
+    })
+  }
+
+  listen (...args) {
+    this.closed = false
+    this.server.on('connection', this.onConnection.bind(this))
+    this.server.on('request', this.wrapRequest.bind(this))
+    return this.server.listen(...args)
+  }
+
+  close (cb) {
+    this.server.removeListener('connection', this.onConnection)
+    this.server.removeListener('request', this.wrapRequest)
+    this.server.close(cb)
+    super.close()
+  }
+
+  destroy (cb) {
+    this.sockets.forEach(socket => {
+      socket.destroy()
+    })
+    super.destroy(cb)
+  }
+}
+
+class BrowserServer extends ServerBase {
+  constructor (client, opts) {
+    super(client, opts)
+
+    this.registration = opts.controller
+    this.workerKeepAliveInterval = null
+    this.workerPortCount = 0
+
+    this.pathname = new URL(opts.controller.scope).pathname + 'webtorrent'
+
+    navigator.serviceWorker.addEventListener('message', this.wrapRequest.bind(this))
+    // test if browser supports cancelling sw Readable Streams
+    fetch(`${this.pathname}/cancel/`).then(res => {
+      res.body.cancel()
+    })
+  }
+
+  wrapRequest (event) {
+    const req = event.data
+
+    if (!req?.type === 'webtorrent' || !req.url) return null
+
+    const [port] = event.ports
+    this.onRequest(req, ({ status, headers, body }) => {
+      const asyncIterator = body instanceof Readable && body[Symbol.asyncIterator]()
+
+      const cleanup = () => {
+        port.onmessage = null
+        if (body?.destroy) body.destroy()
+        this.workerPortCount--
+        if (!this.workerPortCount) {
+          clearInterval(this.workerKeepAliveInterval)
+          this.workerKeepAliveInterval = null
+        }
+      }
+
+      port.onmessage = async msg => {
+        if (msg.data) {
+          let chunk
+          try {
+            chunk = (await asyncIterator.next()).value
+          } catch (e) {
+            // chunk is yet to be downloaded or it somehow failed, should this be logged?
+          }
+          port.postMessage(chunk)
+          if (!chunk) cleanup()
+          if (!this.workerKeepAliveInterval) {
+            this.workerKeepAliveInterval = setInterval(() => fetch(`${this.pathname}/keepalive/`), keepAliveTime)
+          }
+        } else {
+          cleanup()
+        }
+      }
+      this.workerPortCount++
+      port.postMessage({
+        status,
+        headers,
+        body: asyncIterator ? 'STREAM' : body
+      })
+    })
+  }
+
+  close (cb) {
+    navigator.serviceWorker.removeEventListener('message'.this.wrapRequest.bind(this))
+    super.close(cb)
+  }
+
+  destroy (cb) {
+    super.destroy(cb)
+  }
+}
+
 
 // NOTE: Arguments must already be HTML-escaped
 function getPageHTML (title, pageHtml) {
@@ -274,4 +420,4 @@ function encodeRFC5987 (str) {
     .replace(/%(?:7C|60|5E)/g, unescape)
 }
 
-module.exports = Server
+module.exports = { NodeServer, BrowserServer }

--- a/lib/server.js
+++ b/lib/server.js
@@ -27,7 +27,6 @@ class ServerBase {
       ))
       .join('<br>')
 
-
     res.status = 200
     res.headers['Content-Type'] = 'text/html'
     res.body = getPageHTML(
@@ -85,7 +84,6 @@ class ServerBase {
       ))
       .join('<br>')
 
-
     res.status = 200
     res.headers['Content-Type'] = 'text/html'
 
@@ -102,7 +100,6 @@ class ServerBase {
     res.status = 204 // no content
     res.headers['Access-Control-Max-Age'] = '600'
     res.headers['Access-Control-Allow-Methods'] = 'GET,HEAD'
-
 
     if (req.headers['access-control-request-headers']) {
       res.headers['Access-Control-Allow-Headers'] = req.headers['access-control-request-headers']
@@ -151,7 +148,6 @@ class ServerBase {
       range = null
       res.headers['Content-Length'] = file.length
     }
-
 
     const stream = req.method === 'GET' && file.createReadStream(range)
 
@@ -394,7 +390,6 @@ class BrowserServer extends ServerBase {
     super.destroy(cb)
   }
 }
-
 
 // NOTE: Arguments must already be HTML-escaped
 function getPageHTML (title, pageHtml) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -77,7 +77,7 @@ class ServerBase {
     const listHtml = torrent.files
       .map(file => (
     `<li>
-      <a href="${torrent.infoHash}/${escapeHtml(file.path)}">
+      <a href="./${escapeHtml(file.path)}">
         ${escapeHtml(file.path)}
       </a>
       (${escapeHtml(file.length)} bytes)
@@ -217,7 +217,7 @@ class ServerBase {
         return ServerBase.serveTorrentPage(torrent, res)
       }
 
-      const file = torrent.files.find(file => file.path.replace(/\\/, '/') === filePath)
+      const file = torrent.files.find(file => file.path.replace(/\\/g, '/') === filePath)
       if (!file) {
         return ServerBase.serve404Page(res)
       }
@@ -259,6 +259,10 @@ class NodeServer extends ServerBase {
     super(client, opts)
 
     this.server = http.createServer()
+    this._listen = this.server.listen
+    this.server.listen = this.listen.bind(this)
+    this._close = this.server.close
+    this.server.close = this.close.bind(this)
 
     this.sockets = new Set()
     this.pendingReady = new Set()
@@ -301,14 +305,14 @@ class NodeServer extends ServerBase {
     this.closed = false
     this.server.on('connection', this.onConnection.bind(this))
     this.server.on('request', this.wrapRequest.bind(this))
-    return this.server.listen(...args)
+    return this._listen.apply(this.server, args)
   }
 
-  close (cb) {
+  close (cb = () => {}) {
     this.server.removeListener('connection', this.onConnection)
     this.server.removeListener('request', this.wrapRequest)
-    this.server.close(cb)
     super.close()
+    this._close.call(this.server, cb)
   }
 
   destroy (cb) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -381,6 +381,10 @@ class BrowserServer extends ServerBase {
     })
   }
 
+  listen () {
+    // noop for compatibility with node version
+  }
+
   close (cb) {
     navigator.serviceWorker.removeEventListener('message'.this.wrapRequest.bind(this))
     super.close(cb)

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -33,7 +33,6 @@ const utPex = require('ut_pex') // browser exclude
 const File = require('./file.js')
 const Peer = require('./peer.js')
 const RarityMap = require('./rarity-map.js')
-const Server = require('./server.js') // browser exclude
 const utp = require('./utp.js') // browser exclude
 const WebConn = require('./webconn.js')
 
@@ -1844,14 +1843,6 @@ class Torrent extends EventEmitter {
       this._checkDone()
       cb(null)
     })
-  }
-
-  createServer (requestListener) {
-    if (typeof Server !== 'function') throw new Error('node.js-only method')
-    if (this.destroyed) throw new Error('torrent is destroyed')
-    const server = new Server(this, requestListener)
-    this._servers.push(server)
-    return server
   }
 
   pause () {

--- a/lib/worker-server.js
+++ b/lib/worker-server.js
@@ -41,9 +41,18 @@ async function serve ({ request }) {
     }
   })
 
-  if (data.body !== 'STREAM' && data.body !== 'DOWNLOAD') return new Response(data.body, data)
-
   let timeOut = null
+  const cleanup = () => {
+    port.postMessage(false) // send a cancel request
+    clearTimeout(timeOut)
+    port.onmessage = null
+  }
+
+  if (data.body !== 'STREAM') {
+    cleanup()
+    return new Response(data.body, data)
+  }
+
   return new Response(new ReadableStream({
     pull (controller) {
       return new Promise(resolve => {
@@ -51,9 +60,8 @@ async function serve ({ request }) {
           if (data) {
             controller.enqueue(data) // data is Uint8Array
           } else {
-            clearTimeout(timeOut)
+            cleanup()
             controller.close() // data is null, means the stream ended
-            port.onmessage = null
           }
           resolve()
         }
@@ -61,11 +69,9 @@ async function serve ({ request }) {
           // firefox doesn't support cancelling of Readable Streams in service workers,
           // so we just empty it after 5s of inactivity, the browser will request another port anyways
           clearTimeout(timeOut)
-          if (data.body === 'STREAM') {
+          if (destination !== 'document') {
             timeOut = setTimeout(() => {
-              controller.close()
-              port.postMessage(false) // send timeout
-              port.onmessage = null
+              cleanup()
               resolve()
             }, portTimeoutDuration)
           }
@@ -74,9 +80,7 @@ async function serve ({ request }) {
       })
     },
     cancel () {
-      port.postMessage(false) // send a cancel request
-      clearTimeout(timeOut)
-      port.onmessage = null
+      cleanup()
     }
   }), data)
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "url": "https://webtorrent.io"
   },
   "browser": {
-    "./lib/server.js": false,
     "./lib/conn-pool.js": false,
     "./lib/utp.js": false,
     "bittorrent-dht/client": false,

--- a/test/node/server.js
+++ b/test/node/server.js
@@ -14,7 +14,7 @@ test('torrent.createServer: programmatic http server', t => {
 
   client.add(fixtures.leaves.torrent, torrent => {
     t.pass('got "torrent" event')
-    const server = torrent.createServer()
+    const { server } = client.createServer()
 
     server.listen(0, () => {
       const port = server.address().port
@@ -39,16 +39,17 @@ test('torrent.createServer: programmatic http server', t => {
       })
 
       const host = `http://localhost:${port}`
+      const path = `webtorrent/${torrent.infoHash}`
 
       // Index page should list files in the torrent
-      get.concat(`${host}/`, (err, res, data) => {
-        t.error(err, 'got http response for /')
+      get.concat(`${host}/${path}/`, (err, res, data) => {
+        t.error(err, `got http response for /${path}`)
         data = data.toString()
         t.ok(data.includes('Leaves of Grass by Walt Whitman.epub'))
 
         // Verify file content for first (and only) file
-        get.concat(`${host}/0`, (err, res, data) => {
-          t.error(err, 'got http response for /0')
+        get.concat(`${host}/${path}/${torrent.files[0].path}`, (err, res, data) => {
+          t.error(err, `got http response for /${path}/${torrent.files[0].path}`)
           t.deepEqual(data, fixtures.leaves.content)
 
           close()


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->
Requires https://github.com/webtorrent/webtorrent/pull/2336 merged first!!!


**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Unified HTTP server and SW renderer. Both now use almost the same methods and functionality, and behave in the same way.
This means all the functionality the SW was lacking and HTTP server had is available in SW and vice versa.

The SW can now display root indexes of webtorrent which will list all torrents, view indexes of torrents which will list all files etc.

The HTTP server now targets the ENTIRE client, which means its root directory will first list all torrents, then all files.
The HTTP server now causes files to emit `stream` events, just like the SW renderer.

These are breaking changes, the url's for the HTTP server is no longer `/` but `/webtorrent/` and its paths are `/webtorrent/<infohash>` just like my FS changes, to make sure files don't overwrite each other. There's also no more of that useless file identifier thing with index.

The getStreamURL and streamTo methods now also work with the HTTP server for mixed environments such as NWjs or Electron. They also no longer use callbacks.

The client.createServer can be force overwritten to a specific implementation for those mixed environments.

Fixed an edge case where the SW renderer could leave a port open.
Fixed an edge case where weird SW registration paths would cause errors.


Considerations:
for the browser version, should handling the service worker instance the user wants the server to use be done via createServer? or listen method once the server is created?

for the browser version, should we implement the origin path which in theory is possible? or would that be too missleading for some cases?