### PR TITLE
fix: return duplicate torrent on Webtorrent.add()

### DIFF
--- a/index.js
+++ b/index.js
@@ -286,6 +286,8 @@ class WebTorrent extends EventEmitter {
       for (const t of this.torrents) {
         if (t.infoHash === torrent.infoHash && t !== torrent) {
           torrent._destroy(new Error(`Cannot add duplicate torrent ${torrent.infoHash}`))
+          ontorrent(t)
+          this.emit('torrent', t)
           return
         }
       }

--- a/index.js
+++ b/index.js
@@ -287,7 +287,6 @@ class WebTorrent extends EventEmitter {
         if (t.infoHash === torrent.infoHash && t !== torrent) {
           torrent._destroy(new Error(`Cannot add duplicate torrent ${torrent.infoHash}`))
           ontorrent(t)
-          this.emit('torrent', t)
           return
         }
       }


### PR DESCRIPTION
if the there is a duplicate torrent, return the torrent

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[X ] Other, please explain:

**What changes did you make? (Give an overview)**
when we add duplicate torrents, we get an error. this will throw and error but also return the duplicate torrent

**Which issue (if any) does this pull request address?**
duplicate torrents

**Is there anything you'd like reviewers to focus on?**
no, there is nothing specific, only two lines were added
