### PR TITLE
fix: removePeer error after destroy

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -951,17 +951,18 @@ class Torrent extends EventEmitter {
   }
 
   removePeer (peer) {
-    const id = (peer && peer.id) || peer
-    peer = this._peers[id]
+    const id = peer?.id || peer
+    if (peer && !peer.id) peer = this._peers?.[id]
 
     if (!peer) return
+    peer.destroy()
+
+    if (this.destoyed) return
 
     this._debug('removePeer %s', id)
 
     delete this._peers[id]
     this._peersLength -= 1
-
-    peer.destroy()
 
     // If torrent swarm was at capacity before, try to open a new connection now
     this._drain()


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
!!! THIS IS A PATCH, NOT A FIX

seems like `removePeer` was being called after a torrent was destroyed, this was either caused by the peers own [`destroy` function](https://github.com/webtorrent/webtorrent/blob/master/lib/peer.js#L386) or by [pex](https://github.com/webtorrent/webtorrent/blob/master/lib/torrent.js#L1098). I'm not sure as I'm not able to reproduce the issue, but this will fix the ERROR, not any other underlying problems.
**Which issue (if any) does this pull request address?**
#2373 #2299
**Is there anything you'd like reviewers to focus on?**
Does this potentially leak memory? should `peer.destroy` still be called if the peer is an object, not a string ID?