### PR TITLE
fix: typo in `removePeer`

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -957,7 +957,7 @@ class Torrent extends EventEmitter {
     if (!peer) return
     peer.destroy()
 
-    if (this.destoyed) return
+    if (this.destroyed) return
 
     this._debug('removePeer %s', id)
 


### PR DESCRIPTION
Fix a typo from #2398