### PR TITLE
feat: sw renderer tests

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -24,3 +24,4 @@ browserify:
     global: true
     presets: ['@babel/preset-env']
     plugins: ['@babel/plugin-syntax-import-assertions']
+server: './scripts/browser-serve.js'

--- a/index.js
+++ b/index.js
@@ -458,6 +458,12 @@ export default class WebTorrent extends EventEmitter {
       })
     }
 
+    if (this._server) {
+      tasks.push(cb => {
+        this._server.destroy(cb)
+      })
+    }
+
     parallel(tasks, cb)
 
     if (err) this.emit('error', err)

--- a/lib/file.js
+++ b/lib/file.js
@@ -32,7 +32,7 @@ export default class File extends EventEmitter {
       this.emit('done')
     }
 
-    this._server = torrent.client._server
+    this._client = torrent.client
   }
 
   get downloaded () {
@@ -131,8 +131,8 @@ export default class File extends EventEmitter {
   }
 
   getStreamURL () {
-    if (!this._server) throw new Error('No server created')
-    const url = `${this._server.pathname}/${this._torrent.infoHash}/${encodeURI(this.path)}`
+    if (!this._client._server) throw new Error('No server created')
+    const url = `${this._client._server.pathname}/${this._torrent.infoHash}/${encodeURI(this.path)}`
     return url
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,6 +13,7 @@ class ServerBase {
     this.client = client
     if (!opts.origin) opts.origin = '*' // allow all origins by default
     this.opts = opts
+    this.pendingReady = new Set()
   }
 
   static serveIndexPage (res, torrents) {
@@ -261,7 +262,6 @@ class NodeServer extends ServerBase {
     this.server.close = this.close.bind(this)
 
     this.sockets = new Set()
-    this.pendingReady = new Set()
     this.closed = false
     this.pathname = opts?.pathname || '/webtorrent'
   }
@@ -297,6 +297,10 @@ class NodeServer extends ServerBase {
     })
   }
 
+  address () {
+    return this.server.address()
+  }
+
   listen (...args) {
     this.closed = false
     this.server.on('connection', this.onConnection.bind(this))
@@ -305,8 +309,8 @@ class NodeServer extends ServerBase {
   }
 
   close (cb = () => {}) {
-    this.server.removeListener('connection', this.onConnection)
-    this.server.removeListener('request', this.wrapRequest)
+    this.server.removeAllListeners('connection')
+    this.server.removeAllListeners('request')
     super.close()
     this._close.call(this.server, cb)
   }
@@ -327,9 +331,16 @@ class BrowserServer extends ServerBase {
     this.workerKeepAliveInterval = null
     this.workerPortCount = 0
 
-    this.pathname = new URL(opts.controller.scope).pathname + 'webtorrent'
+    const scope = new URL(opts.controller.scope)
+    this.pathname = scope.pathname + 'webtorrent'
+    this._address = {
+      port: scope.port,
+      family: 'IPv4', // might be a bad idea?
+      address: scope.hostname
+    }
 
-    navigator.serviceWorker.addEventListener('message', this.wrapRequest.bind(this))
+    this.boundHandler = this.wrapRequest.bind(this)
+    navigator.serviceWorker.addEventListener('message', this.boundHandler)
     // test if browser supports cancelling sw Readable Streams
     fetch(`${this.pathname}/cancel/`).then(res => {
       res.body.cancel()
@@ -381,12 +392,17 @@ class BrowserServer extends ServerBase {
     })
   }
 
-  listen () {
-    // noop for compatibility with node version
+  // for compatibility with node version
+  listen (_, cb) {
+    cb()
+  }
+
+  address () {
+    return this._address
   }
 
   close (cb) {
-    navigator.serviceWorker.removeEventListener('message'.this.wrapRequest.bind(this))
+    navigator.serviceWorker.removeEventListener('message', this.boundHandler)
     super.close(cb)
   }
 

--- a/package.json
+++ b/package.json
@@ -76,9 +76,9 @@
     "ut_pex": "^3.0.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.2",
+    "@babel/core": "7.20.2",
     "@babel/plugin-syntax-import-assertions": "7.20.0",
-    "@babel/preset-env": "^7.20.2",
+    "@babel/preset-env": "7.20.2",
     "@webtorrent/semantic-release-config": "1.0.8",
     "airtap": "4.0.4",
     "airtap-manual": "1.0.0",

--- a/scripts/browser-serve.js
+++ b/scripts/browser-serve.js
@@ -1,0 +1,7 @@
+import serve from 'serve-static'
+import finalhandler from 'finalhandler'
+import { createServer } from 'http'
+
+createServer((req, res) => {
+  serve('./')(req, res, finalhandler(req, res))
+}).listen(process.env.AIRTAP_SUPPORT_PORT)

--- a/test/browser/basic.js
+++ b/test/browser/basic.js
@@ -1,55 +1,6 @@
 import test from 'tape'
 import WebTorrent from '../../index.js'
 
-// The image append/render tests don't work in electron, so skip them
-// TODO get these working
-// logic taken from https://github.com/atom/electron/issues/2288#issuecomment-123147993
-
-// TODO: test sw renderer, airtap doesnt support static files
-// const img = Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64')
-// img.name = 'img.png'
-// if (!(global && global.process && global.process.versions && global.process.versions.electron)) {
-//   test('sw renderer', t => {
-//     t.plan(1)
-//     const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
-
-//     client.on('error', err => { t.fail(err) })
-//     client.on('warning', err => { t.fail(err) })
-//     try {
-//       navigator.serviceWorker.register('../../sw.min.js', { scope: './' }).then(reg => {
-//         const worker = reg.active || reg.waiting || reg.installing
-//         function checkState (worker) {
-//           t.ok(worker.state === 'activated')
-//           return worker.state === 'activated' && client.createServer({ controller: reg }) && download()
-//         }
-//         if (!checkState(worker)) {
-//           worker.addEventListener('statechange', ({ target }) => checkState(target))
-//         }
-//       })
-//     } catch (e) {
-//       t.err(e)
-//     }
-//     const tag = document.createElement('img')
-//     document.body.appendChild(tag)
-//     function verifyImage (t, elem) {
-//       t.ok(typeof elem.src === 'string')
-//       t.ok(elem.src.includes('webtorrent'))
-//       t.equal(elem.parentElement.nodeName, 'BODY')
-//       elem.remove()
-//     }
-//     function download () {
-//       client.seed(img, torrent => {
-//         torrent.files[0].streamTo(tag, elem => {
-//           verifyImage(t, elem)
-//           client.destroy(err => {
-//             t.error(err, 'client destroyed')
-//           })
-//         })
-//       })
-//     }
-//   })
-// }
-
 test('WebTorrent.WEBRTC_SUPPORT', t => {
   t.plan(2)
 

--- a/test/browser/server.js
+++ b/test/browser/server.js
@@ -1,0 +1,155 @@
+import test from 'tape'
+import WebTorrent from '../../index.js'
+import fixtures from 'webtorrent-fixtures'
+import get from 'simple-get'
+
+// The image append/render tests don't work in electron, so skip them
+// TODO get these working
+// logic taken from https://github.com/atom/electron/issues/2288#issuecomment-123147993
+
+if (!global?.process?.versions?.electron) {
+  const img = Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64')
+  img.name = 'img.png'
+  test('SW Registration and errors', t => {
+    const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
+
+    client.on('error', err => { t.fail(err) })
+    client.on('warning', err => { t.fail(err) })
+
+    client.seed(img, torrent => {
+      t.throws(() => {
+        torrent.files[0].getStreamURL()
+      }, 'Stream URL without server')
+      function checkState (worker, controller) {
+        if (worker.state !== 'activated') {
+          t.throws(() => {
+            client.createServer({ controller })
+          }, 'Invalid worker state')
+        } else {
+          client.createServer({ controller })
+          t.throws(() => {
+            client.createServer({ controller })
+          }, 'Server already registered')
+          t.ok(torrent.files[0].getStreamURL(), 'get file URL')
+          client.destroy(err => {
+            t.error(err, 'client destroyed')
+            t.end()
+          })
+
+          return true
+        }
+      }
+      try {
+        navigator.serviceWorker.register('/sw.min.js', { scope: './' }).then(reg => {
+          const worker = reg.active || reg.waiting || reg.installing
+          if (!checkState(worker)) {
+            worker.addEventListener('statechange', ({ target }) => checkState(target, reg))
+          }
+        })
+      } catch (e) {
+        t.err(e)
+      }
+    })
+  })
+  test('SW renderer image', t => {
+    t.plan(4)
+    const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
+
+    client.on('error', err => { t.fail(err) })
+    client.on('warning', err => { t.fail(err) })
+    try {
+      navigator.serviceWorker.getRegistration().then(controller => {
+        client.createServer({ controller })
+        client.seed(img, async torrent => {
+          const src = torrent.files[0].getStreamURL()
+          t.ok(typeof src === 'string', 'source is string')
+          t.ok(src.endsWith('/webtorrent/db19b51fe04aaf14fd4c9be77f5eeeb2d8789b5c/img.png'), 'source URL is correct')
+
+          const res = await fetch(torrent.files[0].getStreamURL())
+          const data = new Uint8Array(await res.arrayBuffer())
+          const original = new Uint8Array(img)
+          t.deepEqual(data, original)
+          client.destroy(err => {
+            t.error(err, 'client destroyed')
+          })
+        })
+      })
+    } catch (e) {
+      t.err(e)
+    }
+  })
+  test('SW renderer video', t => {
+    t.plan(4)
+    const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
+
+    client.on('error', err => { t.fail(err) })
+    client.on('warning', err => { t.fail(err) })
+    const video = document.createElement('video')
+    try {
+      navigator.serviceWorker.getRegistration().then(controller => {
+        client.createServer({ controller })
+        client.add('https://webtorrent.io/torrents/sintel.torrent', torrent => {
+          video.addEventListener('loadedmetadata', () => {
+            t.equal(Math.floor(video.duration), 888, 'Video metadata')
+            client.destroy(err => {
+              t.error(err, 'client destroyed')
+            })
+          })
+          const file = torrent.files.find(file => file.name.endsWith('.mp4'))
+          file.streamTo(video)
+          t.ok(typeof video.src === 'string', 'source is string')
+          t.ok(video.src.endsWith('/webtorrent/08ada5a7a6183aae1e09d831df6748d566095a10/Sintel/Sintel.mp4'), 'source URL is correct')
+          video.load()
+        })
+      })
+    } catch (e) {
+      t.err(e)
+    }
+  })
+
+  test('client.createServer: programmatic http server [node-like usage]', t => {
+    t.plan(8)
+
+    const client = new WebTorrent({ tracker: false, dht: false, lsd: false })
+
+    client.on('error', err => { t.fail(err) })
+    client.on('warning', err => { t.fail(err) })
+
+    client.seed(fixtures.leaves.content, torrent => {
+      t.pass('got "torrent" event')
+      navigator.serviceWorker.getRegistration().then(controller => {
+        const server = client.createServer({ controller })
+
+        server.listen(0, () => {
+          const port = server.address().port
+          t.pass(`server is listening on ${port}`)
+
+          // Seeding after server is created should work
+
+          const host = `http://localhost:${port}`
+          const path = `webtorrent/${torrent.infoHash}`
+
+          // Index page should list files in the torrent
+          get.concat(`${host}/${path}/`, (err, res, data) => {
+            t.error(err, `got http response for /${path}`)
+            data = data.toString()
+            t.ok(data.includes('Leaves of Grass by Walt Whitman.epub'))
+
+            // Verify file content for first (and only) file
+            get.concat(`${host}/${path}/${torrent.files[0].path}`, (err, res, data) => {
+              t.error(err, `got http response for /${path}/${torrent.files[0].path}`)
+              t.deepEqual(data, fixtures.leaves.content)
+
+              server.close(() => {
+                t.pass('server closed')
+              })
+              client.destroy(err => {
+                t.error(err, 'client destroyed')
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+}

--- a/test/node/server.js
+++ b/test/node/server.js
@@ -4,7 +4,7 @@ import get from 'simple-get'
 import test from 'tape'
 import WebTorrent from '../../index.js'
 
-test('torrent.createServer: programmatic http server', t => {
+test('client.createServer: programmatic http server', t => {
   t.plan(9)
 
   const client = new WebTorrent({ tracker: false, dht: false, lsd: false })
@@ -14,7 +14,7 @@ test('torrent.createServer: programmatic http server', t => {
 
   client.add(fixtures.leaves.torrent, torrent => {
     t.pass('got "torrent" event')
-    const { server } = client.createServer()
+    const server = client.createServer()
 
     server.listen(0, () => {
       const port = server.address().port


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Added quite strict service worker renderer tests, and fixed bugs that creating those tests revealed.

**Which issue (if any) does this pull request address?**
\-

**Is there anything you'd like reviewers to focus on?**
The electron exclusion is there from when render-media was used, I don't understand why it wouldn't work, so I kept it in. Airtap doesn't serve static files, so we need to create a support server in order to register the service worker as it needs to be a standalone file and in the same scope.
Also used an external torrent as fixtures doesn't provide video anymore :/