### PR TITLE
Update file-stream to operate on larger chunks.

### DIFF
--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -50,6 +50,7 @@ class FileStream extends Readable {
     if (!this._reading || this._missing === 0) return cb()
     const maxPieces = Math.floor(this._readLength / this._torrent.pieceLength) | 1
     const piecesToLoad = Math.max(Math.min(maxPieces, this._endPiece - this._piece), 1)
+
     // check that all the pieces we need are available
     // if not mark them as critical and wait for them to be available
     for (let piece = this._piece; piece < this._piece + piecesToLoad; piece++) {
@@ -70,10 +71,14 @@ class FileStream extends Readable {
     if (this._torrent.destroyed) return this.destroy(new Error('Torrent removed'))
 
     let currentRead = Promise.resolve()
-    for (let piece = this._piece; piece < this._piece + piecesToLoad; piece++) {
+    // unclear why, but chrome doesn't emit done
+    // if we use repeated this.push() calls
+    // store read buffers, concat, and push once
+    const bufs = [];
+    for (let piece = this._piece; piece <= this._piece + piecesToLoad; piece++) {
       const getOpts = {}
       // Specify length for the last piece in case it is zero-padded
-      if (piece === this._torrent.pieces.length - 1) {
+      if (piece === this._torrent.pieces.length) {
         getOpts.length = this._torrent.lastPieceLength
       }
       const read = new Promise((resolve, reject) => {
@@ -81,10 +86,12 @@ class FileStream extends Readable {
           if (this.destroyed) return
           debug('read %s (length %s) (err %s)', piece, buffer && buffer.length, err && err.message)
 
-          if (err) {
-            return reject(err)
-          }
-
+          if (err) return reject(err)
+          resolve(buffer)
+        })
+      })
+      currentRead = currentRead.then(() => {
+        return read.then((buffer) => {
           if (this._offset) {
             buffer = buffer.slice(this._offset)
             this._offset = 0
@@ -93,24 +100,19 @@ class FileStream extends Readable {
           if (this._missing < buffer.length) {
             buffer = buffer.slice(0, this._missing)
           }
-          resolve(buffer)
-        })
-      })
-      currentRead = currentRead.then(() => {
-        return read.then((buffer) => {
           this._missing -= buffer.length
-
           debug('pushing buffer of length %s', buffer.length)
-          this.push(buffer)
-          if (this._missing === 0) this.push(null)
+          bufs.push(buffer);
         })
       })
     }
     currentRead.then(() => {
+      this.push(Buffer.concat(bufs));
+      if (this._missing === 0) this.push(null)
       this._notifying = false
       this._reading = false
       this._piece += piecesToLoad
-      this._piece = Math.min(this._piece, this._endPiece)
+      this._piece = Math.min(this._piece, this._endPiece + 1)
       cb()
     }, (err) => {
       this.destroy(err)

--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -82,8 +82,7 @@ class FileStream extends Readable {
           debug('read %s (length %s) (err %s)', piece, buffer && buffer.length, err && err.message)
 
           if (err) {
-            reject(err)
-            return this.destroy(err)
+            return reject(err)
           }
 
           if (this._offset) {
@@ -113,6 +112,8 @@ class FileStream extends Readable {
       this._piece += piecesToLoad
       this._piece = Math.min(this._piece, this._endPiece)
       cb()
+    }, (err) => {
+      this.destroy(err)
     })
   }
 

--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -48,20 +48,19 @@ class FileStream extends Readable {
 
   _notify (cb = () => {}) {
     if (!this._reading || this._missing === 0) return cb()
-    const maxPieces = Math.floor(this._readLength / this._torrent.pieceLength) | 1
-    const piecesToLoad = Math.max(Math.min(maxPieces, this._endPiece - this._piece), 1)
-
+    const maxPieces = Math.floor(this._readLength / this._torrent.pieceLength)
+    let piecesToLoad = Math.max(Math.min(maxPieces, this._endPiece - this._piece + 1), 1)
     // check that all the pieces we need are available
-    // if not mark them as critical and wait for them to be available
-    for (let piece = this._piece; piece < this._piece + piecesToLoad; piece++) {
-      let missingPiece = false
+    // mark the first unavailable piece as critical, process the rest
+    for (let piece = this._piece; piece <= this._piece + piecesToLoad; piece++) {
       if (!this._torrent.bitfield.get(piece)) {
-        missingPiece = true
         this._torrent.critical(piece, piece + this._criticalLength)
-      }
-      if (missingPiece) {
-        cb()
-        return
+        if (piece === this._piece) {
+          return cb()
+        } else {
+          piecesToLoad = piece - this._piece - 1
+          break
+        }
       }
     }
 
@@ -111,8 +110,8 @@ class FileStream extends Readable {
       if (this._missing === 0) this.push(null)
       this._notifying = false
       this._reading = false
-      this._piece += piecesToLoad + 1
-      this._piece = Math.min(this._piece, this._endPiece + 1)
+      this._piece += piecesToLoad + 1;
+      this._piece = Math.min(this._piece, this._endPiece)
       cb()
     }, (err) => {
       this.destroy(err)

--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -23,7 +23,7 @@ class FileStream extends Readable {
       : file.length - 1
 
     const pieceLength = file._torrent.pieceLength
-
+    this._readLength = Math.min(end - start, 1024 * 1024 * 10)
     this._startPiece = (start + file.offset) / pieceLength | 0
     this._endPiece = (end + file.offset) / pieceLength | 0
 
@@ -48,9 +48,20 @@ class FileStream extends Readable {
 
   _notify (cb = () => {}) {
     if (!this._reading || this._missing === 0) return cb()
-    if (!this._torrent.bitfield.get(this._piece)) {
-      cb()
-      return this._torrent.critical(this._piece, this._piece + this._criticalLength)
+    const maxPieces = Math.floor(this._readLength / this._torrent.pieceLength) | 1
+    const piecesToLoad = Math.max(Math.min(maxPieces, this._endPiece - this._piece), 1)
+    // check that all the pieces we need are available
+    // if not mark them as critical and wait for them to be available
+    for (let piece = this._piece; piece < this._piece + piecesToLoad; piece++) {
+      let missingPiece = false
+      if (!this._torrent.bitfield.get(piece)) {
+        missingPiece = true
+        this._torrent.critical(piece, piece + this._criticalLength)
+      }
+      if (missingPiece) {
+        cb()
+        return
+      }
     }
 
     if (this._notifying) return cb()
@@ -58,38 +69,51 @@ class FileStream extends Readable {
 
     if (this._torrent.destroyed) return this.destroy(new Error('Torrent removed'))
 
-    const p = this._piece
+    let currentRead = Promise.resolve()
+    for (let piece = this._piece; piece < this._piece + piecesToLoad; piece++) {
+      const getOpts = {}
+      // Specify length for the last piece in case it is zero-padded
+      if (piece === this._torrent.pieces.length - 1) {
+        getOpts.length = this._torrent.lastPieceLength
+      }
+      const read = new Promise((resolve, reject) => {
+        this._torrent.store.get(piece, getOpts, (err, buffer) => {
+          if (this.destroyed) return
+          debug('read %s (length %s) (err %s)', piece, buffer && buffer.length, err && err.message)
 
-    const getOpts = {}
-    // Specify length for the last piece in case it is zero-padded
-    if (p === this._torrent.pieces.length - 1) {
-      getOpts.length = this._torrent.lastPieceLength
+          if (err) {
+            reject(err)
+            return this.destroy(err)
+          }
+
+          if (this._offset) {
+            buffer = buffer.slice(this._offset)
+            this._offset = 0
+          }
+
+          if (this._missing < buffer.length) {
+            buffer = buffer.slice(0, this._missing)
+          }
+          resolve(buffer)
+        })
+      })
+      currentRead = currentRead.then(() => {
+        return read.then((buffer) => {
+          this._missing -= buffer.length
+
+          debug('pushing buffer of length %s', buffer.length)
+          this.push(buffer)
+          if (this._missing === 0) this.push(null)
+        })
+      })
     }
-    this._torrent.store.get(p, getOpts, (err, buffer) => {
+    currentRead.then(() => {
       this._notifying = false
-      if (this.destroyed) return
-      debug('read %s (length %s) (err %s)', p, buffer && buffer.length, err && err.message)
-
-      if (err) return this.destroy(err)
-
-      if (this._offset) {
-        buffer = buffer.slice(this._offset)
-        this._offset = 0
-      }
-
-      if (this._missing < buffer.length) {
-        buffer = buffer.slice(0, this._missing)
-      }
-      this._missing -= buffer.length
-
-      debug('pushing buffer of length %s', buffer.length)
       this._reading = false
-      this.push(buffer)
-
-      if (this._missing === 0) this.push(null)
+      this._piece += piecesToLoad
+      this._piece = Math.min(this._piece, this._endPiece)
       cb()
     })
-    this._piece += 1
   }
 
   _destroy (cb, err) {

--- a/lib/file-stream.js
+++ b/lib/file-stream.js
@@ -111,7 +111,7 @@ class FileStream extends Readable {
       if (this._missing === 0) this.push(null)
       this._notifying = false
       this._reading = false
-      this._piece += piecesToLoad
+      this._piece += piecesToLoad + 1
       this._piece = Math.min(this._piece, this._endPiece + 1)
       cb()
     }, (err) => {

--- a/test/file-stream.js
+++ b/test/file-stream.js
@@ -4,7 +4,14 @@ const WebTorrent = require('..')
 test('file-stream fetches chunks in parallel, works for large files', (t) => {
   t.plan(2)
   const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
-  const startingData = Buffer.from('0'.repeat(1024 * 1024 * 100))
+  const length = 1024 * 1024 * 11;
+  let idx = 0;
+  let data = '0';
+  while (data.length < length) {
+    data += `${idx}`;
+    idx++
+  }
+  const startingData = Buffer.from(data)
   client.seed(startingData, {
     announce: []
   }, torrent => {
@@ -39,7 +46,14 @@ test('file-stream fetches chunks in parallel, works for large files', (t) => {
 test('file-stream works for small files', (t) => {
   t.plan(1)
   const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
-  const startingData = Buffer.from('0'.repeat(1023 * 100))
+  const length = 1023 * 100;
+  let idx = 0;
+  let data = '0';
+  while (data.length < length) {
+    data += `${idx}`;
+    idx++
+  }
+  const startingData = Buffer.from(data)
   client.seed(startingData, {
     dht: false,
     announce: []

--- a/test/file-stream.js
+++ b/test/file-stream.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 const WebTorrent = require('..')
 
-test('file-stream supports a readsize option', (t) => {
+test('file-stream fetches chunks in parallel', (t) => {
   t.plan(2)
   const client = new WebTorrent({ dht: false, announce: [] })
   const startingData = Buffer.from('0'.repeat(1024 * 1024 * 100))

--- a/test/file-stream.js
+++ b/test/file-stream.js
@@ -1,9 +1,9 @@
 const test = require('tape')
 const WebTorrent = require('..')
 
-test('file-stream fetches chunks in parallel', (t) => {
+test('file-stream fetches chunks in parallel, works for large files', (t) => {
   t.plan(2)
-  const client = new WebTorrent({ dht: false, announce: [] })
+  const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
   const startingData = Buffer.from('0'.repeat(1024 * 1024 * 100))
   client.seed(startingData, {
     announce: []
@@ -25,13 +25,42 @@ test('file-stream fetches chunks in parallel', (t) => {
     })
     readStream.on('end', () => {
       const readTime = Date.now() - start
+      t.deepEqual(Buffer.concat(data), startingData)
       // reading should be much faster than doing so sequentially,
       // but it's difficult to assert this based solely on clock.
       // Let's just shoot for 20x faster.
       const upperLimit = artificialDelay * torrent.pieces.length / 20
       t.assert(readTime < upperLimit, `expect read time: ${readTime} to be less than ${upperLimit}`)
-      t.deepEqual(Buffer.concat(data), startingData)
       client.destroy()
     })
   })
 })
+
+test('file-stream works for small files', (t) => {
+  t.plan(1)
+  const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
+  const startingData = Buffer.from('0'.repeat(1023 * 100))
+  client.seed(startingData, {
+    dht: false,
+    announce: []
+  }, torrent => {
+    const artificialDelay = 10 // simulate a slow chunk look up, 10ms
+    const origGet = torrent.store.get
+    torrent.store.get = function (...rest) {
+      const _this = this
+      setTimeout(() => {
+        origGet.apply(_this, rest)
+      }, artificialDelay)
+    }
+    // time the total
+    const readStream = torrent.files[0].createReadStream()
+    const data = []
+    readStream.on('data', (d) => {
+      data.push(d)
+    })
+    readStream.on('end', () => {
+      t.deepEqual(Buffer.concat(data), startingData)
+      client.destroy()
+    })
+  });
+});

--- a/test/file-stream.js
+++ b/test/file-stream.js
@@ -1,0 +1,37 @@
+const test = require('tape')
+const WebTorrent = require('..')
+
+test('file-stream supports a readsize option', (t) => {
+  t.plan(2)
+  const client = new WebTorrent({ dht: false, announce: [] })
+  const startingData = Buffer.from('0'.repeat(1024 * 1024 * 100))
+  client.seed(startingData, {
+    announce: []
+  }, torrent => {
+    const start = Date.now()
+    const artificialDelay = 10 // simulate a slow chunk look up, 10ms
+    const origGet = torrent.store.get
+    torrent.store.get = function (...rest) {
+      const _this = this
+      setTimeout(() => {
+        origGet.apply(_this, rest)
+      }, artificialDelay)
+    }
+    // time the total
+    const readStream = torrent.files[0].createReadStream()
+    const data = []
+    readStream.on('data', (d) => {
+      data.push(d)
+    })
+    readStream.on('end', () => {
+      const readTime = Date.now() - start
+      // reading should be much faster than doing so sequentially,
+      // but it's difficult to assert this based solely on clock.
+      // Let's just shoot for 20x faster.
+      const upperLimit = artificialDelay * torrent.pieces.length / 20
+      t.assert(readTime < upperLimit, `expect read time: ${readTime} to be less than ${upperLimit}`)
+      t.deepEqual(Buffer.concat(data), startingData)
+      client.destroy()
+    })
+  })
+})


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain:

**What changes did you make? (Give an overview)**
I updated file-stream to read in batches of 10mb where possible.

I did this because I'm using the idb-chunk-store instead of the default in memory store. IndexDB allows for huge amounts of additional storage (especially compared to memory), but is slow. Each chunk (16kb) lookup takes 5-25ms. In practice this meant reading a single 7mb file would take up to 3 seconds in my app.

After doing some local testing I found I could read the entire contents of the file in ~20ms by requesting each chunk in parallel.

This change batches requests to 10mb where possible, limiting the memory used, but more fully saturating w/e the async bottleneck is in indexDB, but appends content serially. 

**Which issue (if any) does this pull request address?**
N/A

**Is there anything you'd like reviewers to focus on?**

Error handling? I added a happy path test, but I'm not sure if I got everything correct here. Will be using in my own project in the mean time and will port back any fixes that I have to make there.