### PR TITLE
fix: infinite error loop, connecting after destroy

### DIFF
--- a/lib/peer.js
+++ b/lib/peer.js
@@ -363,6 +363,7 @@ class Peer extends EventEmitter {
     this.connected = false
 
     debug('destroy %s %s (error: %s)', this.type, this.id, err && (err.message || err))
+    this.emit('destroy', err)
 
     clearTimeout(this.connectTimeout)
     clearTimeout(this.handshakeTimeout)

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -946,6 +946,10 @@ class Torrent extends EventEmitter {
       this.client.emit('upload', uploaded)
     })
 
+    newPeer.on('destroy', () => {
+      this.removePeer(newPeer)
+    })
+
     this._peers[newPeer.id] = newPeer
     this._peersLength += 1
   }
@@ -1857,7 +1861,7 @@ class Torrent extends EventEmitter {
 
     const conn = peer.conn
 
-    conn.once('connect', () => { peer.onConnect() })
+    conn.once('connect', () => { if (!this.destroyed) peer.onConnect() })
     conn.once('error', err => { peer.destroy(err) })
     peer.startConnectTimeout()
 


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Added a destroy event to peer, which torrent listens to, to clean up peer connections. Added a destroy check to peer's onConnect.

**Which issue (if any) does this pull request address?**
- fix: https://github.com/webtorrent/webtorrent/issues/2405

Fixed an issue which caused an infinite error loop that leaked insane amts of memory when a wire unexpectedly closed, as webtorrent would keep trying to request pieces from a [closed wire, fail](https://github.com/webtorrent/webtorrent/blob/master/lib/torrent.js#L1683-L1690), and retry via [_retry](https://github.com/webtorrent/webtorrent/blob/master/lib/torrent.js#L1307-L1326). This wasn't as noticable in browser thanks to the idle timeout

![image](https://user-images.githubusercontent.com/6506529/205453122-1226936d-e59f-4af6-85b2-dd9d89bdf730.png)
![image](https://user-images.githubusercontent.com/6506529/205453130-04ef0540-d083-4bc3-9816-bc662640b4b7.png)

This looped forever, my PC ran out of RAM at ~10k of those errors