### PR TITLE
fix: standard linting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  env: {
+    es2022: true,
+    browser: true,
+    node: true,
+    serviceworker: true
+  },
+  extends: ['standard'],
+  parser: '@babel/eslint-parser',
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 'latest',
+    requireConfigFile: false,
+    babelOptions: {
+      parserOpts: {
+        plugins: ['importAssertions']
+      }
+    }
+  },
+  ignorePatterns: ['node_modules', 'dist']
+}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,4 @@
 /*! webtorrent. MIT License. WebTorrent LLC <https://webtorrent.io/opensource> */
-/* global FileList */
-/* eslint-env browser */
-
 import EventEmitter from 'events'
 import path from 'path'
 import concat from 'simple-concat'

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1,5 +1,3 @@
-/* global Blob */
-
 import EventEmitter from 'events'
 import fs from 'fs'
 import net from 'net' // browser exclude

--- a/lib/worker-server.js
+++ b/lib/worker-server.js
@@ -1,6 +1,3 @@
-/* global clients, MessageChannel, ReadableStream, Response */
-/* eslint-env serviceworker */
-
 const portTimeoutDuration = 5000
 let cancellable = false
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,5 +1,3 @@
-/* eslint-env serviceworker */
-
 import fileResponse from './worker-server.js'
 
 self.addEventListener('install', () => {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@webtorrent/http-node": "^1.3.0",
     "addr-to-ip-port": "^1.5.4",
     "bitfield": "^4.1.0",
-    "bittorrent-protocol": "^4.0.1",
     "bittorrent-dht": "^10.0.7",
+    "bittorrent-protocol": "^4.0.1",
     "cache-chunk-store": "^3.2.2",
     "chunk-store-iterator": "^1.0.2",
     "cpus": "^1.0.3",
@@ -76,6 +76,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.20.2",
+    "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-syntax-import-assertions": "7.20.0",
     "@babel/preset-env": "7.20.2",
     "@webtorrent/semantic-release-config": "1.0.8",
@@ -87,6 +88,11 @@
     "buffer": "^6.0.3",
     "chrome-net": "^3.3.4",
     "disc": "1.3.3",
+    "eslint": "^8.32.0",
+    "eslint-config-standard": "^17.0.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-n": "^15.6.1",
+    "eslint-plugin-promise": "^6.1.1",
     "finalhandler": "1.2.0",
     "network-address": "1.1.2",
     "pako": "^2.1.0",
@@ -94,7 +100,6 @@
     "run-series": "1.1.9",
     "semantic-release": "20.0.2",
     "serve-static": "1.15.0",
-    "standard": "*",
     "stream-http": "^3.2.0",
     "tap-spec": "^5.0.0",
     "tape": "5.6.3",
@@ -157,19 +162,11 @@
     "size": "npm run size-js && npm run size-disc",
     "size-disc": "npm run build-js && cat ./dist/webtorrent.min.js | discify --open",
     "size-js": "npm run build-js && cat ./dist/webtorrent.min.js | gzip | wc -c",
-    "test": "standard && npm run test-node && npm run test-browser | tap-spec",
+    "test": "eslint . && npm run test-node && npm run test-browser | tap-spec",
     "test-browser": "airtap --concurrency 1 -- test/*.js test/browser/*.js | tap-spec",
     "test-browser-local": "airtap --preset local -- test/*.js test/browser/*.js | tap-spec",
     "test-node": "tape test/*.js test/node/*.js | tap-spec",
-
     "update-authors": "./scripts/update-authors.sh"
-  },
-  "standard": {
-    "ignore": [
-      "webtorrent.min.js",
-      "sw.min.js",
-      "webtorrent.chromeapp.js"
-    ]
   },
   "renovate": {
     "extends": [

--- a/test/client-seed.js
+++ b/test/client-seed.js
@@ -1,5 +1,3 @@
-/* global Blob */
-
 import fixtures from 'webtorrent-fixtures'
 import test from 'tape'
 import WebTorrent from '../index.js'


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
migrated from standard cli to eslint, and created a custom eslint config for it
**Which issue (if any) does this pull request address?**
standard cli doesn't support many new features like import assertions etc, this fixes that, it also allows us to globally define globals [kek]
**Is there anything you'd like reviewers to focus on?**
on the surface it might seem like this brings in a lot of new dependencies, but in reality standard already imported all these dependencies and more, so this actually reduces the amt of packages downloaded

this would have been nice to do in package.json's `standard` field, but it doesn't accept `parserOptions` as a field, which means we'd need extra config files regardless