### PR TITLE
fix: revert bittorent-protocol ver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
         node:
           - '18'
           - '16'
-          - '14'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "addr-to-ip-port": "^1.5.4",
     "bitfield": "^4.1.0",
     "bittorrent-dht": "^10.0.7",
-    "bittorrent-protocol": "^4.0.1",
+    "bittorrent-protocol": "^3.5.5",
     "cache-chunk-store": "^3.2.2",
     "chunk-store-iterator": "^1.0.2",
     "cpus": "^1.0.3",


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Reverted bittorrent-protocol version.
**Which issue (if any) does this pull request address?**
Fixes CI hanging, however the unreasonable thing is that the only difference between 3.5.5 and 4.0.1 is that it's ESM and no longer uses setInterval, yet it causes the tests to hang, specifically conn-pool where the metadata event listener never fires, even tho the event is dispatched correctly, is this because of GC?
**Is there anything you'd like reviewers to focus on?**
