### PR TITLE
server: Support serving the .torrent file

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -90,9 +90,17 @@ class ServerBase {
     res.body = getPageHTML(
         `${escapeHtml(torrent.name)} - WebTorrent`,
         `<h1>${escapeHtml(torrent.name)}</h1>
-        <ol>${listHtml}</ol>`
+        <ol>${listHtml}</ol>
+        <a href="${escapeHtml(pathname)}/${torrent.infoHash}.torrent">download .torrent</a>`
     )
 
+    return res
+  }
+
+  static serveTorrentMeta (torrent, res) {
+    res.status = 200
+    res.headers['Content-Type'] = 'application/x-bittorrent'
+    res.body = torrent.torrentFile
     return res
   }
 
@@ -210,8 +218,13 @@ class ServerBase {
         return ServerBase.serveIndexPage(res, this.client.torrents, this.pathname)
       }
 
-      let [infoHash, ...filePath] = pathname.split('/')
+      let [infoHash, ...filePath] = pathname.split('/'), serveTorrentMeta = false
       filePath = decodeURI(filePath.join('/'))
+
+      if (infoHash.endsWith('.torrent')) {
+        infoHash = infoHash.slice(0, -8)
+        serveTorrentMeta = true
+      }
 
       const torrent = await this.client.get(infoHash)
       if (!infoHash || !torrent) {
@@ -219,7 +232,11 @@ class ServerBase {
       }
 
       if (!filePath) {
-        return ServerBase.serveTorrentPage(torrent, res, this.pathname)
+        if (serveTorrentMeta) {
+          return ServerBase.serveTorrentMeta(torrent, res)
+        } else {
+          return ServerBase.serveTorrentPage(torrent, res, this.pathname)
+        }
       }
 
       const file = torrent.files.find(file => file.path.replace(/\\/g, '/') === filePath)


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

This adds support for serving the `.torrent` metadata file from the webserver via `/webtorrent/<infohash>.torrent`.

For my use-case, I was looking to use the webserver as the magnet `xs` source for the torrent file. Alongside `ws`, this [makes it possible](https://github.com/webtorrent/webtorrent/issues/1393#issuecomment-389805621) to use the webserver to create magnet links with an HTTP fallback that works even when there are no peers on the bittorrent network.
