### PR TITLE
server: Redirect single-file torrents to the file

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -73,6 +73,12 @@ class ServerBase {
   }
 
   static serveTorrentPage (torrent, res, pathname) {
+    if (torrent.files.length == 1) {
+      res.status = 301
+      res.headers.Location = `${pathname}/${torrent.infoHash}/${torrent.files[0].path}`
+      return res
+    }
+
     const listHtml = torrent.files
       .map(file => (
     `<li>


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

For single-file torrents, this redirects the torrent's main page to the path of the file itself.

Among other things, this makes it easier to embed files on external sites given only the `infohash`, without knowing the filename. (i.e. `<img src="https://example.com/webtorrent/f6f2289eb1f4848691edbf4e5be5a982df6b1bec">`)
