### PR TITLE
Replace setting blob 'mimeType' property with 'type'

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -138,7 +138,7 @@ export default class File extends EventEmitter {
   }
 
   async blob (opts) {
-    return new Blob([await this.arrayBuffer(opts)], { mimeType: this.type })
+    return new Blob([await this.arrayBuffer(opts)], { type: this.type })
   }
 
   stream (opts) {


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

The Blob returned by File.blob() incorrectly set the `mimeType` property, where it should be `type`.
See: https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob

**Which issue (if any) does this pull request address?**
No issue posted.

**Is there anything you'd like reviewers to focus on?**
