### PR TITLE
 Prevent emitting completed event to trackers multiple time

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -164,17 +164,6 @@ export default class Torrent extends EventEmitter {
     return downloaded
   }
 
-  // TODO: re-enable this. The number of missing pieces. Used to implement 'end game' mode.
-  // Object.defineProperty(Storage.prototype, 'numMissing', {
-  //   get: function () {
-  //     var self = this
-  //     var numMissing = self.pieces.length
-  //     for (var index = 0, len = self.pieces.length; index < len; index++) {
-  //       numMissing -= self.bitfield.get(index)
-  //     }
-  //     return numMissing
-  //   }
-  // })
 
   get downloadSpeed () { return this._downloadSpeed() }
 
@@ -1814,7 +1803,14 @@ export default class Torrent extends EventEmitter {
       }
       if (!done) break
     }
-
+    if (done) {
+      for (const reservation of this._reservations) {
+        if (!this.bitfield.get(reservation.piece)) {
+          done = false;
+          break;
+        }
+      }
+    }
     if (!this.done && done) {
       this.done = true
       this._debug(`torrent done: ${this.infoHash}`)

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -164,6 +164,17 @@ export default class Torrent extends EventEmitter {
     return downloaded
   }
 
+  // TODO: re-enable this. The number of missing pieces. Used to implement 'end game' mode.
+  // Object.defineProperty(Storage.prototype, 'numMissing', {
+  //   get: function () {
+  //     var self = this
+  //     var numMissing = self.pieces.length
+  //     for (var index = 0, len = self.pieces.length; index < len; index++) {
+  //       numMissing -= self.bitfield.get(index)
+  //     }
+  //     return numMissing
+  //   }
+  // })
 
   get downloadSpeed () { return this._downloadSpeed() }
 


### PR DESCRIPTION
Prevent emitting completed event to trackers multiple time

fixes: https://github.com/webtorrent/webtorrent/issues/2441