### PR TITLE
fix: node server stream leaks

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -2,9 +2,12 @@ import http from 'http'
 import escapeHtml from 'escape-html'
 import rangeParser from 'range-parser'
 import queueMicrotask from 'queue-microtask'
-import { Readable, pipeline } from 'streamx'
+import stream from 'stream'
+import streamx from 'streamx'
 
 const keepAliveTime = 20000
+
+const noop = () => {}
 
 class ServerBase {
   constructor (client, opts = {}) {
@@ -30,8 +33,8 @@ class ServerBase {
     res.headers['Content-Type'] = 'text/html'
     res.body = getPageHTML(
       'WebTorrent',
-        `<h1>WebTorrent</h1>
-         <ol>${listHtml}</ol>`
+      `<h1>WebTorrent</h1>
+       <ol>${listHtml}</ol>`
     )
 
     return res
@@ -74,12 +77,12 @@ class ServerBase {
   static serveTorrentPage (torrent, res, pathname) {
     const listHtml = torrent.files
       .map(file => (
-    `<li>
-      <a href="${escapeHtml(pathname)}/${torrent.infoHash}/${escapeHtml(file.path)}">
-        ${escapeHtml(file.path)}
-      </a>
-      (${escapeHtml(file.length)} bytes)
-    </li>`
+      `<li>
+        <a href="${escapeHtml(pathname)}/${torrent.infoHash}/${escapeHtml(file.path)}">
+          ${escapeHtml(file.path)}
+        </a>
+        (${escapeHtml(file.length)} bytes)
+      </li>`
       ))
       .join('<br>')
 
@@ -87,9 +90,9 @@ class ServerBase {
     res.headers['Content-Type'] = 'text/html'
 
     res.body = getPageHTML(
-        `${escapeHtml(torrent.name)} - WebTorrent`,
-        `<h1>${escapeHtml(torrent.name)}</h1>
-        <ol>${listHtml}</ol>`
+      `${escapeHtml(torrent.name)} - WebTorrent`,
+      `<h1>${escapeHtml(torrent.name)}</h1>
+      <ol>${listHtml}</ol>`
     )
 
     return res
@@ -149,26 +152,19 @@ class ServerBase {
     }
 
     if (req.method === 'GET') {
-      const iterator = file[Symbol.asyncIterator](range)
-      let transform = null
+      let iterator = file[Symbol.asyncIterator](range)
       file.emit('iterator', { iterator, req, file }, target => {
-        transform = target
+        iterator = target
       })
 
-      const stream = Readable.from(transform || iterator)
-      let pipe = null
-      file.emit('stream', { stream, req, file }, target => {
-        pipe = pipeline(stream, target)
-      })
-
-      res.body = pipe || stream
+      res.body = { file, iterator }
     } else {
       res.body = false
     }
     return res
   }
 
-  async onRequest (req, cb) {
+  onRequest (req, cb) {
     let pathname = new URL(req.url, 'http://example.com').pathname
     pathname = pathname.slice(pathname.indexOf(this.pathname) + this.pathname.length + 1)
 
@@ -198,13 +194,12 @@ class ServerBase {
       else return cb(ServerBase.serveMethodNotAllowed(res))
     }
 
-    const onReady = async () => {
+    const onReady = () => {
       this.pendingReady.delete(onReady)
-      const res = await handleRequest()
-      cb(res)
+      cb(handleRequest())
     }
 
-    const handleRequest = async () => {
+    const handleRequest = () => {
       if (pathname === '') {
         return ServerBase.serveIndexPage(res, this.client.torrents, this.pathname)
       }
@@ -212,7 +207,7 @@ class ServerBase {
       let [infoHash, ...filePath] = pathname.split('/')
       filePath = decodeURI(filePath.join('/'))
 
-      const torrent = await this.client.get(infoHash)
+      const torrent = this.client.torrents.find(torrent => torrent.infoHash === infoHash)
       if (!infoHash || !torrent) {
         return ServerBase.serve404Page(res)
       }
@@ -230,7 +225,7 @@ class ServerBase {
 
     if (req.method === 'GET' || req.method === 'HEAD') {
       if (this.client.ready) {
-        const res = await handleRequest()
+        const res = handleRequest()
         return cb(res)
       } else {
         this.pendingReady.add(onReady)
@@ -239,10 +234,10 @@ class ServerBase {
       }
     }
 
-    return ServerBase.serveMethodNotAllowed(res)
+    return cb(ServerBase.serveMethodNotAllowed(res))
   }
 
-  close (cb = () => {}) {
+  close (cb = noop) {
     this.closed = true
     this.pendingReady.forEach(onReady => {
       this.client.removeListener('ready', onReady)
@@ -251,7 +246,7 @@ class ServerBase {
     queueMicrotask(cb)
   }
 
-  destroy (cb = () => {}) {
+  destroy (cb = noop) {
     // Only call `server.close` if user has not called it already
     if (this.closed) queueMicrotask(cb)
     else this.close(cb)
@@ -289,8 +284,13 @@ class NodeServer extends ServerBase {
     this.onRequest(req, ({ status, headers, body }) => {
       res.writeHead(status, headers)
 
-      if (!!body._readableState || !!body._writableState) {
-        pipeline(body, res)
+      if (body.iterator) {
+        const _stream = stream.Readable.from(body.iterator)
+        let pipe
+        body.file.emit('stream', { stream: _stream, req, file: body.file }, target => {
+          pipe = target
+        })
+        stream.pipeline([_stream, pipe, res].filter(n => n), noop)
       } else {
         res.end(body)
       }
@@ -316,7 +316,7 @@ class NodeServer extends ServerBase {
     return this._listen.apply(this.server, args)
   }
 
-  close (cb = () => {}) {
+  close (cb = noop) {
     this.server.removeAllListeners('connection')
     this.server.removeAllListeners('request')
     this.server.removeAllListeners('listening')
@@ -363,7 +363,14 @@ class BrowserServer extends ServerBase {
 
     const [port] = event.ports
     this.onRequest(req, ({ status, headers, body }) => {
-      const asyncIterator = body instanceof Readable && body[Symbol.asyncIterator]()
+      let asyncIterator = null
+      if (body.iterator) {
+        const stream = streamx.Readable.from(body.iterator)
+        asyncIterator = stream[Symbol.asyncIterator]()
+        body.file.emit('stream', { stream, req, file: body.file }, target => {
+          asyncIterator = streamx.pipeline(stream, target)[Symbol.asyncIterator]()
+        })
+      }
 
       const cleanup = () => {
         port.onmessage = null

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "load-ip-set": false,
     "net": false,
     "os": false,
+    "stream": false,
     "ut_pex": false
   },
   "bugs": {
@@ -33,6 +34,7 @@
     "net": "chrome-net",
     "querystring": "querystring",
     "fs": false,
+    "stream": false,
     "os": false
   },
   "dependencies": {

--- a/scripts/browser.webpack.js
+++ b/scripts/browser.webpack.js
@@ -11,7 +11,6 @@ export default {
     alias: {
       ...info.browser,
       crypto: false,
-      stream: 'readable-stream',
       path: 'path-browserify'
     }
   },


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
streamx just doesn't work when mixed with node:stream, quite often when the streams closed the streamx streams didn't close their underlying iterators, leaking them, which left a lot of active selections on files/ranges which we were no longer interested in

This was simply fixed by using `stream` in node and `streamx` in browser, since in browser we use the underling iterator anyways, not the stream itself