### PR TITLE
fix: Revert "fix: correctly destroy piped streams in server"

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -31,8 +31,8 @@ class ServerBase {
     res.headers['Content-Type'] = 'text/html'
     res.body = getPageHTML(
       'WebTorrent',
-        `<h1>WebTorrent</h1>
-         <ol>${listHtml}</ol>`
+      `<h1>WebTorrent</h1>
+       <ol>${listHtml}</ol>`
     )
 
     return res
@@ -75,12 +75,12 @@ class ServerBase {
   static serveTorrentPage (torrent, res, pathname) {
     const listHtml = torrent.files
       .map(file => (
-    `<li>
-      <a href="${escapeHtml(pathname)}/${torrent.infoHash}/${escapeHtml(file.path)}">
-        ${escapeHtml(file.path)}
-      </a>
-      (${escapeHtml(file.length)} bytes)
-    </li>`
+      `<li>
+        <a href="${escapeHtml(pathname)}/${torrent.infoHash}/${escapeHtml(file.path)}">
+          ${escapeHtml(file.path)}
+        </a>
+        (${escapeHtml(file.length)} bytes)
+      </li>`
       ))
       .join('<br>')
 
@@ -88,9 +88,9 @@ class ServerBase {
     res.headers['Content-Type'] = 'text/html'
 
     res.body = getPageHTML(
-        `${escapeHtml(torrent.name)} - WebTorrent`,
-        `<h1>${escapeHtml(torrent.name)}</h1>
-        <ol>${listHtml}</ol>`
+      `${escapeHtml(torrent.name)} - WebTorrent`,
+      `<h1>${escapeHtml(torrent.name)}</h1>
+      <ol>${listHtml}</ol>`
     )
 
     return res
@@ -240,7 +240,7 @@ class ServerBase {
       }
     }
 
-    return ServerBase.serveMethodNotAllowed(res)
+    return cb(ServerBase.serveMethodNotAllowed(res))
   }
 
   close (cb = () => {}) {
@@ -290,7 +290,7 @@ class NodeServer extends ServerBase {
     this.onRequest(req, ({ status, headers, body }) => {
       res.writeHead(status, headers)
 
-      if (body instanceof Readable) { // this is probably a bad way of checking? idk
+      if (!!body._readableState || !!body._writableState) { // this is probably a bad way of checking? idk
         pump(body, res)
       } else {
         res.end(body)
@@ -364,7 +364,7 @@ class BrowserServer extends ServerBase {
 
     const [port] = event.ports
     this.onRequest(req, ({ status, headers, body }) => {
-      const asyncIterator = body instanceof Readable && body[Symbol.asyncIterator]()
+      const asyncIterator = body[Symbol.asyncIterator]?.()
 
       const cleanup = () => {
         port.onmessage = null

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,8 +1,9 @@
 import http from 'http'
 import escapeHtml from 'escape-html'
+import pump from 'pump'
 import rangeParser from 'range-parser'
 import queueMicrotask from 'queue-microtask'
-import { Readable, pipeline } from 'streamx'
+import { Readable } from 'streamx'
 
 const keepAliveTime = 20000
 
@@ -158,7 +159,7 @@ class ServerBase {
       const stream = Readable.from(transform || iterator)
       let pipe = null
       file.emit('stream', { stream, req, file }, target => {
-        pipe = pipeline(stream, target)
+        pipe = pump(stream, target)
       })
 
       res.body = pipe || stream
@@ -289,8 +290,8 @@ class NodeServer extends ServerBase {
     this.onRequest(req, ({ status, headers, body }) => {
       res.writeHead(status, headers)
 
-      if (!!body._readableState || !!body._writableState) {
-        pipeline(body, res)
+      if (body instanceof Readable) { // this is probably a bad way of checking? idk
+        pump(body, res)
       } else {
         res.end(body)
       }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "mime": "^3.0.0",
     "once": "^1.4.0",
     "parse-torrent": "^11.0.12",
+    "pump": "^3.0.0",
     "queue-microtask": "^1.2.3",
     "random-iterate": "^1.0.1",
     "range-parser": "^1.2.1",


### PR DESCRIPTION
Reverts webtorrent/webtorrent#2565

makes stream/iterator check less strict