### PR TITLE
fix: malformed debug ID

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ export default class WebTorrent extends EventEmitter {
     }
     this.nodeIdBuffer = hex2arr(this.nodeId)
 
-    this._debugId = arr2hex(this.peerId).substring(0, 7)
+    this._debugId = this.peerId.substring(0, 7)
 
     this.destroyed = false
     this.listening = false


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

You can see debug messages from WebTorrent with the `DEBUG` environment variable. For example, in this repository:

```sh
DEBUG=webtorrent npm test
```

Debug messages should contain the first 7 characters of the peer ID. However, they currently look like this:

    webtorrent [02undef] listening +7ms

"02undef" seems wrong. After this change, the debug ID looks correct:

    webtorrent [2d57573] listening +7ms

This happened because `peerId` is a string but was mistakenly being treated like a buffer.

**Which issue (if any) does this pull request address?**

No GitHub issues I'm aware of.

**Is there anything you'd like reviewers to focus on?**

No.
