### PR TITLE
fix: iterate over destroyed torrent

### DIFF
--- a/lib/file-iterator.js
+++ b/lib/file-iterator.js
@@ -51,7 +51,11 @@ export default class FileIterator extends EventEmitter {
             }
           }
           this._torrent.on('verified', listener)
-          return this._torrent.critical(index, index + this._criticalLength)
+          try {
+            return this._torrent.critical(index, index + this._criticalLength)
+          } catch (err) {
+            reject(err)
+          }
         }
 
         if (this._torrent.destroyed) return reject(new Error('Torrent removed'))


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Fix an issue when iterating over a file could cause the library to crash due to an unhandled error in promise. This change adds a try/catch around `this._torrent.critical(index, index + this._criticalLength)` which can throw an error if the torrent is destroyed.

**Which issue (if any) does this pull request address?**

There is no open issues related to this one.

**Is there anything you'd like reviewers to focus on?**

This issue would occur when a file read is made while a torrent is being destroyed.
