### PR TITLE
Make "always choke seeders" optional

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -126,7 +126,8 @@ If `opts` is specified, then the default options (shown below) will be overridde
   strategy: String,          // Piece selection strategy, `rarest` or `sequential`(defaut=`sequential`)
   noPeersIntervalTime: Number, // The amount of time (in seconds) to wait between each check of the `noPeers` event (default=30)
   paused: Boolean,           // If true, create the torrent in a paused state (default=false)
-  deselect: Boolean          // If true, create the torrent with no pieces selected (default=false)
+  deselect: Boolean,         // If true, create the torrent with no pieces selected (default=false)
+  alwaysChokeSeeders: Boolean // If true, client will automatically choke seeders if it's seeding. (default=true)
 }
 ```
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1199,8 +1199,7 @@ export default class Torrent extends EventEmitter {
         if (!wire.peerPieces.get(i)) return
       }
       wire.isSeeder = true
-      if (this.alwaysChokeSeeders)
-        wire.choke() // always choke seeders
+      if (this.alwaysChokeSeeders) wire.choke() // always choke seeders
     }
 
     wire.on('bitfield', () => {
@@ -1224,8 +1223,7 @@ export default class Torrent extends EventEmitter {
     // fast extension (BEP6)
     wire.on('have-all', () => {
       wire.isSeeder = true
-      if (this.alwaysChokeSeeders)
-        wire.choke() // always choke seeders
+      if (this.alwaysChokeSeeders) wire.choke() // always choke seeders
       this._update()
       this._updateWireInterest(wire)
     })

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -88,7 +88,7 @@ export default class Torrent extends EventEmitter {
     this._destroyStoreOnDestroy = opts.destroyStoreOnDestroy || false
     this.store = null
     this.storeOpts = opts.storeOpts
-    this.alwaysChokeSeeders = opts.alwaysChokeSeeders !== undefined ? opts.alwaysChokeSeeders : true;
+    this.alwaysChokeSeeders = opts.alwaysChokeSeeders ?? true
 
     this._getAnnounceOpts = opts.getAnnounceOpts
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -88,6 +88,7 @@ export default class Torrent extends EventEmitter {
     this._destroyStoreOnDestroy = opts.destroyStoreOnDestroy || false
     this.store = null
     this.storeOpts = opts.storeOpts
+    this.alwaysChokeSeeders = opts.alwaysChokeSeeders !== undefined ? opts.alwaysChokeSeeders : true;
 
     this._getAnnounceOpts = opts.getAnnounceOpts
 
@@ -1198,7 +1199,8 @@ export default class Torrent extends EventEmitter {
         if (!wire.peerPieces.get(i)) return
       }
       wire.isSeeder = true
-      wire.choke() // always choke seeders
+      if (this.alwaysChokeSeeders)
+        wire.choke() // always choke seeders
     }
 
     wire.on('bitfield', () => {
@@ -1222,7 +1224,8 @@ export default class Torrent extends EventEmitter {
     // fast extension (BEP6)
     wire.on('have-all', () => {
       wire.isSeeder = true
-      wire.choke() // always choke seeders
+      if (this.alwaysChokeSeeders)
+        wire.choke() // always choke seeders
       this._update()
       this._updateWireInterest(wire)
     })


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Turn "always choke seeders" into an option (enabled by default).

**Which issue (if any) does this pull request address?**
When disabled, the client won't choke other seeders while it's seeding.

**Is there anything you'd like reviewers to focus on?**
Although the average person wouldn't want to change this setting, it is useful for custom [bittorrent extensions](http://github.com/webtorrent/bittorrent-protocol) which would like to keep peers unchoked. I would appreciate a PR as my bittorrent extension still needs seeding clients to communicate.