### PR TITLE
Replace import ... assert calls with import ... with

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ import ConnPool from './lib/conn-pool.js' // browser exclude
 import Torrent from './lib/torrent.js'
 import { NodeServer, BrowserServer } from './lib/server.js'
 
-import info from './package.json' assert { type: 'json' }
+import info from './package.json' with { type: 'json' }
 const VERSION = info.version
 
 const debug = debugFactory('webtorrent')

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -35,7 +35,7 @@ import utp from './utp.cjs' // browser exclude
 import WebConn from './webconn.js'
 import { Selections } from './selections.js'
 
-import info from '../package.json' assert { type: 'json' }
+import info from '../package.json' with { type: 'json' }
 
 const debug = debugFactory('webtorrent:torrent')
 const MAX_BLOCK_LENGTH = 128 * 1024

--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -6,7 +6,7 @@ import { hash, concat } from 'uint8-util'
 import Wire from 'bittorrent-protocol'
 import once from 'once'
 
-import info from '../package.json' assert { type: 'json' }
+import info from '../package.json' with { type: 'json' }
 
 const debug = debugFactory('webtorrent:webconn')
 const VERSION = info.version


### PR DESCRIPTION
Fixes compatibility with Node 22

**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**
I replaced the deprecated(?) `assert` statement with `with`. This has fixed use of the lib with Node 22. I haven't tested it any further.
**Which issue (if any) does this pull request address?**
#2777
**Is there anything you'd like reviewers to focus on?**
Mentioned in the issue, webpack compatibility might be an issue?