### PR TITLE
feat: Enable outbound connections when seeding by default

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -69,6 +69,7 @@ If `opts` is specified, then the default options (shown below) will be overridde
   natPmp: Boolean,         // Enable NAT port mapping via NAT-PMP (default=true). NodeJS only.
   webSeeds: Boolean,       // Enable BEP19 web seeds (default=true)
   utp: Boolean,            // Enable BEP29 uTorrent transport protocol (default=true)
+  seedOutgoingConnections: Boolean // Enable outgoing connections when seeding (default=true)
   blocklist: Array|String, // List of IP's to block
   downloadLimit: Number,   // Max download speed (bytes/sec) over all torrents (default=-1)
   uploadLimit: Number,     // Max upload speed (bytes/sec) over all torrents (default=-1)
@@ -87,6 +88,8 @@ For possible values of `opts.blocklist` see the
 For `opts.natUpnp` and `opts.natPmp`, if both are set to `true`, PMP will be attempted first, then fallback to UPNP. NodeJS only.
 
 For `opts.natUpnp`, if set to `true`, a temporary mapping is used, if set to `permanent`, a permanent TTL will be used for UPNP if the router only supports permanent leases. NodeJS only.
+
+For `opts.seedOutgoingConnections`, if set `true`, outgoing connections will be established while seeding, otherwise, only inbound connections will be responded to.
 
 For `downloadLimit` and `uploadLimit` the possible values can be:
   - `> 0`. The client will set the throttle at that speed

--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ export default class WebTorrent extends EventEmitter {
     this.torrents = []
     this.maxConns = Number(opts.maxConns) || 55
     this.utp = WebTorrent.UTP_SUPPORT && opts.utp !== false
+    this.seedOutgoingConnections = opts.seedOutgoingConnections ?? true
 
     this._downloadLimit = Math.max((typeof opts.downloadLimit === 'number') ? opts.downloadLimit : -1, -1)
     this._uploadLimit = Math.max((typeof opts.uploadLimit === 'number') ? opts.uploadLimit : -1, -1)

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -359,8 +359,11 @@ export default class Torrent extends EventEmitter {
 
     this.discovery.on('peer', (peer, source) => {
       this._debug('peer %s discovered via %s', peer, source)
-      // Don't create new outgoing TCP connections when torrent is done
-      if (typeof peer === 'string' && this.done) return
+      // Don't create new outgoing connections when torrent is done and seedOutgoingConnections is false.
+      if (!this.client.seedOutgoingConnections && this.done) {
+        this._debug('ignoring peer %s: torrent is done and seedOutgoingConnections is false', peer)
+        return
+      }
       this.addPeer(peer, source)
     })
 


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR introduces the client option `opts.seedOutgoingConnections` which allows users to control the behaviour implemented in #709, allowing WebTorrent to create outbound connections while seeding to improve peer discovery/connectivity.

**Which issue (if any) does this pull request address?**
- fixes #2781

**Is there anything you'd like reviewers to focus on?**
