### PR TITLE
FIX: import assert deprecation in NodeJS 22

### DIFF
--- a/config.cjs
+++ b/config.cjs
@@ -1,0 +1,2 @@
+// Exports package.json to work around "with" and "assert" for backwards compatability.
+module.exports = require('./package.json')

--- a/index.js
+++ b/index.js
@@ -17,8 +17,7 @@ import ConnPool from './lib/conn-pool.js' // browser exclude
 import Torrent from './lib/torrent.js'
 import { NodeServer, BrowserServer } from './lib/server.js'
 
-import info from './config.cjs'
-const VERSION = info.version
+import VERSION from './version.cjs'
 
 const debug = debugFactory('webtorrent')
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ import ConnPool from './lib/conn-pool.js' // browser exclude
 import Torrent from './lib/torrent.js'
 import { NodeServer, BrowserServer } from './lib/server.js'
 
-import info from './package.json' assert { type: 'json' }
+import info from './config.cjs'
 const VERSION = info.version
 
 const debug = debugFactory('webtorrent')

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -35,7 +35,7 @@ import utp from './utp.cjs' // browser exclude
 import WebConn from './webconn.js'
 import { Selections } from './selections.js'
 
-import info from '../package.json' assert { type: 'json' }
+import info from '../config.cjs'
 
 const debug = debugFactory('webtorrent:torrent')
 const MAX_BLOCK_LENGTH = 128 * 1024

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -35,7 +35,7 @@ import utp from './utp.cjs' // browser exclude
 import WebConn from './webconn.js'
 import { Selections } from './selections.js'
 
-import info from '../config.cjs'
+import VERSION from '../version.cjs'
 
 const debug = debugFactory('webtorrent:torrent')
 const MAX_BLOCK_LENGTH = 128 * 1024
@@ -56,7 +56,6 @@ const FILESYSTEM_CONCURRENCY = process.browser ? cpus().length : 2
 
 const RECONNECT_WAIT = [1_000, 5_000, 15_000]
 
-const VERSION = info.version
 const USER_AGENT = `WebTorrent/${VERSION} (https://webtorrent.io)`
 
 let TMP

--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -6,7 +6,7 @@ import { hash, concat } from 'uint8-util'
 import Wire from 'bittorrent-protocol'
 import once from 'once'
 
-import info from '../package.json' assert { type: 'json' }
+import info from '../config.cjs'
 
 const debug = debugFactory('webtorrent:webconn')
 const VERSION = info.version

--- a/lib/webconn.js
+++ b/lib/webconn.js
@@ -6,10 +6,9 @@ import { hash, concat } from 'uint8-util'
 import Wire from 'bittorrent-protocol'
 import once from 'once'
 
-import info from '../config.cjs'
+import VERSION from '../version.cjs'
 
 const debug = debugFactory('webtorrent:webconn')
-const VERSION = info.version
 
 const SOCKET_TIMEOUT = 60000
 const RETRY_DELAY = 10000

--- a/version.cjs
+++ b/version.cjs
@@ -1,2 +1,2 @@
 // Exports package.json to work around "with" and "assert" for backwards compatability.
-module.exports = require('./package.json')
+module.exports = require('./package.json').version


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
This change adds `config.cjs`, which allows us to require `package.json`, which works across all versions of NodeJS >= 16, resolving the issue with `assert` requiring NodeJS >= 16  and NodeJS <=21 and `with` requiring NodeJS >= 22.

**Which issue (if any) does this pull request address?**
- fixes https://github.com/webtorrent/webtorrent/issues/2777
- fixes https://github.com/webtorrent/webtorrent-cli/issues/309
- closes https://github.com/webtorrent/webtorrent/pull/2797

**Is there anything you'd like reviewers to focus on?**
- Are we fine with `config.cjs`, or would `package.cjs` or something else make more sense? 