### PR TITLE
fix: allow client level default trackers to be set

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -276,6 +276,11 @@ export default class Torrent extends EventEmitter {
       parsedTorrent.announce = parsedTorrent.announce.concat(this.announce)
     }
 
+    if (this.client.tracker && Array.isArray(this.client.tracker.announce) && !parsedTorrent.private) {
+      // If the client has a default tracker, add it to the announce list if torrent is not private
+      parsedTorrent.announce = parsedTorrent.announce.concat(this.client.tracker.announce)
+    }
+
     if (this.client.tracker && global.WEBTORRENT_ANNOUNCE && !parsedTorrent.private) {
       // So `webtorrent-hybrid` can force specific trackers to be used
       parsedTorrent.announce = parsedTorrent.announce.concat(global.WEBTORRENT_ANNOUNCE)

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -271,7 +271,7 @@ export default class Torrent extends EventEmitter {
       parsedTorrent.private = this.private
     }
 
-    if (this.announce) {
+    if (Array.isArray(this.announce)) {
       // Allow specifying trackers via `opts` parameter
       parsedTorrent.announce = parsedTorrent.announce.concat(this.announce)
     }


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR fixes the current issue that client option `{ tracker: { announce: [] }` is being ignored and not being concatenated to the torrents announce list for non-private torrents.

This PR additionally changes a small truthy check to Array.isArray, to prevent an object / other values from being incorrectly passed on `client.add` or `client.seed` option `announce`.

**Which issue (if any) does this pull request address?**
- fixes https://github.com/webtorrent/webtorrent/issues/2376

**Is there anything you'd like reviewers to focus on?**
