### PR TITLE
fix: force streamx version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "run-parallel": "^1.2.0",
     "run-parallel-limit": "^1.1.0",
     "speed-limiter": "^1.0.2",
-    "streamx": "^2.17.0",
+    "streamx": "2.17.0",
     "throughput": "^1.0.1",
     "torrent-discovery": "^11.0.6",
     "torrent-piece": "^3.0.0",


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
locked streamx ver
**Which issue (if any) does this pull request address?**
streamx 2.18 introduced setEncoding which imports massive dependencies for text and uint8 parsing, lock 1 version b4 to exclude them since we really dont need them
**Is there anything you'd like reviewers to focus on?**
