### PR TITLE
fix: uTP error on setup

### DIFF
--- a/lib/conn-pool.js
+++ b/lib/conn-pool.js
@@ -42,8 +42,10 @@ export default class ConnPool {
       this._client._destroy(err)
     }
 
-    this._onUTPError = () => {
+    this._onUTPError = (err) => {
       this._client.utp = false
+      this._client.emit('error', err)
+      if (!this._client.listening) this._onListening()
     }
 
     // Setup TCP

--- a/test/node/conn-pool.js
+++ b/test/node/conn-pool.js
@@ -147,7 +147,7 @@ test('client.conn-pool: adding IPv6 peer when uTP enabled should fallback to TCP
 
 // Warning: slow test as we need to rely on connection timeouts
 test('client.conn-pool: fallback to TCP when uTP server failed', t => {
-  t.plan(6)
+  t.plan(7)
 
   // force uTP server failure
   const server = dgram.createSocket('udp4')
@@ -156,7 +156,7 @@ test('client.conn-pool: fallback to TCP when uTP server failed', t => {
   const client1 = new WebTorrent({ dht: false, tracker: false, lsd: false, utp: true, torrentPort: 63000 })
   const client2 = new WebTorrent({ dht: false, tracker: false, lsd: false, utp: false })
 
-  client1.on('error', err => { t.fail(err) })
+  client1.on('error', err => { t.equal(err.toString(), 'Error: address already in use') })
   client1.on('warning', err => { t.fail(err) })
 
   client2.on('error', err => { t.fail(err) })


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
it's possible for uTP to error on `listen` which disables utp, however it hangs the client indefinetly, as onListening never fired, this fixes that, the errors were also swallowed, thats not a good thing, tcp server logs its error on destroy, however utp server didnt! this was a bad implementation!
**Which issue (if any) does this pull request address?**
onListening is safe to fire right away on utp error, as utp can only error once tcp server has already started listening
**Is there anything you'd like reviewers to focus on?**
