### PR TITLE
fix: bad done and select behavior and documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -585,6 +585,12 @@ torrent errors. Torrent errors are not fatal, and the client is still usable
 afterwards. Therefore, always listen for errors in both places
 (`client.on('error')` and `torrent.on('error')`).
 
+## `torrent.on('idle', function () {})`
+
+Emitted when the torrent has no more active selections to download, and starts idling 
+or seeding. This can happen when a file is fully downloaded, or when the desired pieces
+have been downloaded.
+
 ## `torrent.on('done', function () {})`
 
 Emitted when all the torrent files have been downloaded.
@@ -684,8 +690,6 @@ Useful if you know you need the file at a later stage.
 ## `file.deselect()`
 
 Deselects the file's specific priority, which means it won't be downloaded unless someone creates a stream for it.
-
-*Note: This method is currently not working as expected, see [dcposch answer on #164](https://github.com/webtorrent/webtorrent/issues/164) for a nice work around solution.
 
 ## `stream = file.createReadStream([opts])`
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -370,7 +370,7 @@ export default class Torrent extends EventEmitter {
       this._debug('peer %s discovered via %s', peer, source)
       // Don't create new outgoing connections when torrent is done and seedOutgoingConnections is false.
       if (!this.client.seedOutgoingConnections && this.done) {
-        this._debug('ignoring peer %s: torrent is done and seedOutgoingConnections is false', peer)
+        this._debug('discovery ignoring peer %s: torrent is done and seedOutgoingConnections is false', peer)
         return
       }
       this.addPeer(peer, source)
@@ -1032,7 +1032,7 @@ export default class Torrent extends EventEmitter {
     this._drain()
   }
 
-  _select (start, end, priority, notify, isStreamSelection = false) {
+  _select (start = 0, end = this.pieces.length - 1, priority, notify, isStreamSelection = false) {
     if (this.destroyed) throw new Error('torrent is destroyed')
 
     if (start < 0 || end < start || this.pieces.length <= end) {
@@ -1150,8 +1150,11 @@ export default class Torrent extends EventEmitter {
       wire.use(utPex())
 
       wire.ut_pex.on('peer', peer => {
-        // Only add potential new peers when we're not seeding
-        if (this.done) return
+        // Only add potential new peers when torrent is done and seedOutgoingConnections is false.
+        if (!this.client.seedOutgoingConnections && this.done) {
+          this._debug('ut_pex ignoring peer %s: torrent is done and seedOutgoingConnections is false', peer)
+          return
+        }
         this._debug('ut_pex: got peer: %s (from %s)', peer, addr)
         this.addPeer(peer, Peer.SOURCE_UT_PEX)
       })
@@ -1778,9 +1781,7 @@ export default class Torrent extends EventEmitter {
               wire.have(index)
             })
           }
-          // We also check `self.destroyed` since `torrent.destroy()` could have been
-          // called in the `torrent.on('done')` handler, triggered by `_checkDone()`.
-          if (self._checkDone() && !self.destroyed) self.discovery.complete()
+          self._checkDone()
           onUpdateTick()
         })
       } else {
@@ -1811,26 +1812,23 @@ export default class Torrent extends EventEmitter {
       this._debug(`file done: ${file.name}`)
     })
 
-    // is the torrent done? (if all current selections are satisfied, or there are
-    // no selections, then torrent is done)
-    let done = true
-
-    for (const selection of this._selections) {
-      for (let piece = selection.from; piece <= selection.to; piece++) {
-        if (!this.bitfield.get(piece)) {
-          done = false
-          break
-        }
-      }
-      if (!done) break
-    }
+    // is the torrent done? (if everything is downloaded)
+    const done = this.files.every(file => file.done)
 
     if (!this.done && done) {
       this.done = true
       this._debug(`torrent done: ${this.infoHash}`)
       this.emit('done')
-    } else {
+      // We also check `this.destroyed` since `torrent.destroy()` could have been
+      // called in the `torrent.on('done')` handler.
+      if (!this.destroyed) this.discovery.complete()
+    } else if (this.done && !done) {
       this.done = false
+      // this isn't according to spec, once a torrent is done it's done, but we allow devs
+      // to unmark pieces, so to re-download them we need to re-announce to
+      // trackers that "hey we need peers". This means triggering complete multiple times
+      // thats bad, but can't do much about it.
+      this.discovery.tracker?.start()
     }
     this._gcSelections()
 

--- a/test/node/torrent-events.js
+++ b/test/node/torrent-events.js
@@ -84,7 +84,7 @@ test('client.seed: emit torrent events in order', t => {
   })
 })
 
-test('file.select: check multiple done events', t => {
+test('file.select: check multiple idle events', t => {
   t.plan(5)
 
   const client1 = new WebTorrent({ dht: false, tracker: false, lsd: false, utp: false })
@@ -123,7 +123,7 @@ test('file.select: check multiple done events', t => {
       t.equal(++order, 3)
     })
 
-    torrent.on('done', () => {
+    torrent.on('idle', () => {
       ++order
 
       if (order === 4) {


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Documentation around the torrent done state was incorrect. A torrent was done when all it's selections were satisfied, NOT when it's fully downloaded, unlike file.done, which does state if a file is fully downloaded [![image](https://cdn.discordapp.com/emojis/893580086744326204.webp?size=20&animated=true)]
This is now corrected. According to BEP03 done and complete should only emit after a FULL download, FAST seems to agree in this regard. The `idle` event and `done` events behaved the same, so now `idle` means "all selections done" and `done` means 100% downloaded.

Calling select with no pieces didn't error, but broke things, assign for selecting to download the entire torrent.

Enable seedOutgoingConnections wasn't implemented for ut_PEX.

When making piece as undone, the tracker didnt re-emit the "started" event, which is bad for peer discovery, which means it was possible for it to not be able to re-download now newly missing pieces, it now does that, even tho the spec doesn't really like that, but it beats the client hanging indefinetly.
**Which issue (if any) does this pull request address?**
https://github.com/webtorrent/webtorrent/issues/2441
https://github.com/webtorrent/webtorrent/issues/1517
**Is there anything you'd like reviewers to focus on?**