### PR TITLE
log warning instead of exception when calling critical on destroyed torrent

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1076,7 +1076,7 @@ export default class Torrent extends EventEmitter {
 
   critical (start, end) {
     if (this.destroyed) {
-      console.warning('ignoring critical request, torrent is destroyed', start, end)
+      this.emit('warning', new Error(`ignoring critical on destroyed torrent ${start}-${end}`))
       return
     }
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -1075,7 +1075,10 @@ export default class Torrent extends EventEmitter {
   }
 
   critical (start, end) {
-    if (this.destroyed) throw new Error('torrent is destroyed')
+    if (this.destroyed) {
+      console.warning('ignoring critical request, torrent is destroyed', start, end)
+      return
+    }
 
     this._debug('critical %s-%s', start, end)
 


### PR DESCRIPTION
instead of throwing when critical is called, log a warning (as this crashes the entire server and cannot be caught)

fixes #2923 