### PR TITLE
fix: remove stream selection

### DIFF
--- a/lib/selections.js
+++ b/lib/selections.js
@@ -27,18 +27,16 @@ export class Selections {
   remove (item) {
     for (let i = 0; i < this._items.length; i++) {
       const existing = this._items[i]
+      // we only remove stream selections when the `isStreamSelection` flag match, cast to boolean using !
+      if (!existing.isStreamSelection !== !item.isStreamSelection) continue
+
       if (existing.isStreamSelection) {
-        if (item.isStreamSelection) {
-          // If both are stream selections and they match, then we remove the first matching item, then we break the loop
-          if (existing.from === item.from && existing.to === item.to) {
-            this._items.splice(i, 1)
-            // for stream selections, we only remove one item at a time
-            // ergo we break the loop after removing the first matching item
-            break
-          }
-        } else {
-          // we only remove stream selections when the `isStreamSelection` flag is true and they match
-          continue
+        // If both are stream selections and they match, then we remove the first matching item, then we break the loop
+        if (existing.from === item.from && existing.to === item.to) {
+          this._items.splice(i, 1)
+          // for stream selections, we only remove one item at a time
+          // ergo we break the loop after removing the first matching item
+          break
         }
       } else {
         if (isLowerIntersecting(item, existing)) {


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
fixed an issue which caused all selections to be removed during video playback/seeking

this was caused as `existing` did not check for match with `item` for `isStreamSelection`, so if a video with a selection of bytes `0/length` aka 0 to infinity [as it doesn't have a stream end] was removed, ex: by seeking, it would deselect the entire file, which meant no buffering ahead... woe
