### PR TITLE
fix: move serve-static middleware out of request handler

### DIFF
--- a/scripts/browser-serve.js
+++ b/scripts/browser-serve.js
@@ -2,6 +2,9 @@ import serve from 'serve-static'
 import finalhandler from 'finalhandler'
 import { createServer } from 'http'
 
+// instantiate middleware only once (outside request handler)
+const serveStatic = serve('./dist/')
+
 createServer((req, res) => {
-  serve('./dist/')(req, res, finalhandler(req, res))
+  serveStatic(req, res, finalhandler(req, res))
 }).listen(process.env.AIRTAP_SUPPORT_PORT)


### PR DESCRIPTION
 Inefficient middleware instantiation in scripts/browser-serve.js
 File:

scripts/browser-serve.js
 Problem:

The current code instantiates the serve-static middleware on every request, which is inefficient:

import serve from 'serve-static'
import finalhandler from 'finalhandler'
import { createServer } from 'http'

createServer((req, res) => {
  serve('./dist/')(req, res, finalhandler(req, res))
}).listen(process.env.AIRTAP_SUPPORT_PORT)

 Why it matters:

    serve('./dist/') returns a middleware function. Creating it inside the request handler causes it to be re-initialized on every request, which is unnecessary.

    This can lead to performance issues, especially in test environments or with many concurrent requests.

    It's a minor bug but considered bad practice and could lead to future side effects.

 Suggested Fix:

Move the middleware instantiation outside the server callback:

const serveStatic = serve('./dist/')

createServer((req, res) => {
  serveStatic(req, res, finalhandler(req, res))
}).listen(process.env.AIRTAP_SUPPORT_PORT || 3000)

Optional Enhancements:

const serveStatic = serve('./dist/', {
  index: ['index.html'],
  maxAge: '1h',
})