### PR TITLE
feat: peers as map for performance

### DIFF
--- a/lib/peer.js
+++ b/lib/peer.js
@@ -72,6 +72,7 @@ export default class Peer extends EventEmitter {
   onConnect () {
     if (this.destroyed) return
     this.connected = true
+    this.emit('connected')
 
     debug('Peer %s connected', this.id)
 

--- a/lib/selections.js
+++ b/lib/selections.js
@@ -7,8 +7,9 @@
 /** A selection of pieces to download.
  * @typedef {MinimalSelectionItem & {
  *  offset: number,
- *  priority: number,
+ *  priority?: number,
  *  notify?: function
+ *  remove?: function,
  *  isStreamSelection?: boolean
  * }} SelectionItem
  */
@@ -36,6 +37,7 @@ export class Selections {
           this._items.splice(i, 1)
           // for stream selections, we only remove one item at a time
           // ergo we break the loop after removing the first matching item
+          // stream selections are non-unique, so this is in a way a count
           break
         }
       } else {
@@ -60,30 +62,58 @@ export class Selections {
   }
 
   /**
+   * Merges the priority and notify functions of two selection items.
+   * @param {SelectionItem} newItem
+   * @param {SelectionItem} existing
+   */
+  _mergePriorityAndNotify (newItem, existing) {
+    if ((existing.priority ?? 0) > (newItem.priority ?? 0)) {
+      newItem.priority = existing.priority
+    }
+
+    if (newItem.notify && existing.notify) {
+      const oldNotify = newItem.notify
+      newItem.notify = () => {
+        oldNotify()
+        existing.notify?.()
+      }
+    } else {
+      newItem.notify = existing.notify || newItem.notify
+    }
+  }
+
+  concatenate (newItem) {
+    for (let i = 0; i < this._items.length; i++) {
+      const existing = this._items[i]
+
+      if (!existing.isStreamSelection) {
+        if (isLowerIntersecting(newItem, existing)) {
+          newItem.from = existing.from
+        } else if (isUpperIntersecting(newItem, existing)) {
+          newItem.to = existing.to
+        } else if (isInsideExisting(newItem, existing)) {
+          newItem.from = existing.from
+          newItem.to = existing.to
+        } else if (isCoveringExisting(newItem, existing)) {
+          continue
+        } else {
+          continue
+        }
+        this._mergePriorityAndNotify(newItem, existing)
+      }
+    }
+
+    this.remove(newItem)
+  }
+
+  /**
    * @param {SelectionItem & NotificationItem} newItem
    */
   insert (newItem) {
     if (newItem.from > newItem.to) {
       throw new Error('Invalid interval')
     }
-    if (!newItem.isStreamSelection) {
-      const { notify: oldNotify } = newItem
-      // Merge notifications of intersecting items into the new item's notify function
-      const intersectingNotifyFunctions = []
-      for (const existing of this._items) {
-        if (existing.notify && isIntersecting(newItem, existing)) {
-          intersectingNotifyFunctions.push(existing.notify)
-        }
-      }
-      if (intersectingNotifyFunctions.length > 0) {
-        newItem.notify = () => {
-          intersectingNotifyFunctions.forEach(fn => fn())
-          oldNotify?.()
-        }
-      }
-      // Remove or truncate intersecting items to make room for the new item
-      this.remove(newItem)
-    }
+    if (!newItem.isStreamSelection) this.concatenate(newItem)
     this._items.push(newItem)
   }
 
@@ -111,7 +141,7 @@ export class Selections {
     this._items.length = 0
   }
 
-  /** @returns {Generator<SelectionItem & {remove: () => void, replaceWith: (MinimalSelectionItem[]) => void}>} */
+  /** @returns {Generator<SelectionItem & {remove: function}>} */
   * [Symbol.iterator] () {
     for (let i = 0; i < this._items.length; i++) {
       const item = this._items[i]

--- a/lib/selections.js
+++ b/lib/selections.js
@@ -165,7 +165,7 @@ export class Selections {
  * @returns {boolean} returns true if the new item's lower end is intersecting with the existing item
  */
 export function isLowerIntersecting (newItem, existing) {
-  return (newItem.from <= existing.to) && (newItem.from > existing.from) && (newItem.to > existing.to)
+  return (newItem.from <= existing.to + 1) && (newItem.from > existing.from) && (newItem.to > existing.to)
 }
 
 /**
@@ -177,7 +177,7 @@ export function isLowerIntersecting (newItem, existing) {
  * @returns {boolean} returns true if the new item's upper end is intersecting with the existing item
  */
 export function isUpperIntersecting (newItem, existing) {
-  return (newItem.to >= existing.from) && (newItem.to < existing.to) && (newItem.from < existing.from)
+  return (newItem.to >= existing.from - 1) && (newItem.to < existing.to) && (newItem.from < existing.from)
 }
 
 /**

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -262,13 +262,7 @@ export default class Torrent extends EventEmitter {
     return this._queue.length + (this._peersLength - this._numConns)
   }
 
-  get _numConns () {
-    let numConns = 0
-    for (const peer of this._peers.values()) {
-      if (peer.connected) numConns += 1
-    }
-    return numConns
-  }
+  _numConns = 0
 
   /**
    * Parse a torrent from its magnet/torrent file/remote url and kickstart downloading it
@@ -1183,6 +1177,9 @@ export default class Torrent extends EventEmitter {
     this._registerPeer(peer)
   }
 
+  /**
+   * @param {Peer} newPeer
+   */
   _registerPeer (newPeer) {
     newPeer.on('download', downloaded => {
       if (this.destroyed) return
@@ -1204,6 +1201,15 @@ export default class Torrent extends EventEmitter {
       this.client.emit('upload', uploaded)
     })
 
+    if (newPeer.connected) {
+      this._numConns += 1
+    } else {
+      newPeer.once('connect', () => {
+        if (this.destroyed) return
+        this._numConns += 1
+      })
+    }
+
     this._peers.set(newPeer.id, newPeer)
     this._peersLength += 1
   }
@@ -1213,6 +1219,7 @@ export default class Torrent extends EventEmitter {
     if (peer && !peer.id) peer = this._peers?.get(id)
 
     if (!peer) return
+    const wasConnected = peer.connected
     peer.destroy()
 
     if (this.destroyed) return
@@ -1221,6 +1228,7 @@ export default class Torrent extends EventEmitter {
 
     this._peers.delete(id)
     this._peersLength -= 1
+    if (wasConnected) this._numConns -= 1
 
     // If torrent swarm was at capacity before, try to open a new connection now
     this._drain()

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -627,7 +627,7 @@ export default class Torrent extends EventEmitter {
     } else {
       // start off selecting the entire torrent with low priority
       if (this.pieces.length !== 0 && !this._startAsDeselected) {
-        this.select(0, this.pieces.length - 1, 0)
+        this.select(0, this.pieces.length - 1)
       }
     }
 
@@ -893,7 +893,7 @@ export default class Torrent extends EventEmitter {
       : this.pieceLength
     this.pieces[index] = new Piece(len)
     this.bitfield.set(index, false)
-    if (!this._startAsDeselected) this.select(index, index, 1)
+    if (!this._startAsDeselected) this.select(index, index)
     for (const file of this.files) {
       if (file.done && file.includes(index)) file.done = false
     }
@@ -1748,7 +1748,6 @@ export default class Torrent extends EventEmitter {
         } else {
           for (piece = next.from + next.offset; piece <= next.to; piece++) {
             if (!wire.peerPieces.get(piece) || !rank(piece)) continue
-            const requestsBefore = wire.requests.length
 
             while (self._request(wire, piece, self._critical[piece] || hotswap) &&
               wire.requests.length < maxOutstandingRequests) {
@@ -1756,12 +1755,10 @@ export default class Torrent extends EventEmitter {
               // request all non-reserved blocks in piece
             }
 
-            if (wire.requests.length >= maxOutstandingRequests) {
-              if (next.priority) shufflePriority(i)
-              return true
-            }
+            if (wire.requests.length < maxOutstandingRequests) continue
 
-            if (wire.requests.length > requestsBefore) break
+            if (next.priority) shufflePriority(i)
+            return true
           }
         }
       }

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -178,11 +178,18 @@ export default class Torrent extends EventEmitter {
     this._amInterested = false
     this._selections = new Selections()
     this._critical = []
-
-    this.wires = [] // open wires (added *after* handshake)
+    /**
+     * open wires (added *after* handshake)
+     * @type {import('bittorrent-protocol').default[]}
+     */
+    this.wires = []
 
     this._queue = [] // queue of outgoing tcp peers to connect to
-    this._peers = {} // connected peers (addr/peerId -> Peer)
+    /**
+     * connected peers (addr/peerId -> Peer)
+     * @type {Map<string, Peer>}
+     */
+    this._peers = new Map()
     this._peersLength = 0 // number of elements in `this._peers` (cache, for perf)
 
     // stats
@@ -257,8 +264,8 @@ export default class Torrent extends EventEmitter {
 
   get _numConns () {
     let numConns = 0
-    for (const id in this._peers) {
-      if (this._peers[id].connected) numConns += 1
+    for (const peer of this._peers.values()) {
+      if (peer.connected) numConns += 1
     }
     return numConns
   }
@@ -466,7 +473,7 @@ export default class Torrent extends EventEmitter {
           numPeers: 0
         }
       }
-      for (const peer of Object.values(this._peers)) {
+      for (const peer of this._peers.values()) {
         const counter = counters[peer.source]
         if (typeof counter !== 'undefined') counter.numPeers++
       }
@@ -969,7 +976,7 @@ export default class Torrent extends EventEmitter {
       this._rarityMap.destroy()
     }
 
-    for (const id in this._peers) {
+    for (const id of this._peers.keys()) {
       this.removePeer(id)
     }
 
@@ -1025,6 +1032,7 @@ export default class Torrent extends EventEmitter {
     this.discovery = null
     this.store = null
     this._rarityMap = null
+    this._peers.clear()
     this._peers = null
     this._servers = null
     this._xsRequests = null
@@ -1082,7 +1090,7 @@ export default class Torrent extends EventEmitter {
     }
 
     const id = (peer && peer.id) || peer
-    if (this._peers[id]) {
+    if (this._peers.has(id)) {
       this._debug('ignoring peer: duplicate (%s)', id)
       if (typeof peer !== 'string') peer.destroy()
       return null
@@ -1132,7 +1140,7 @@ export default class Torrent extends EventEmitter {
         return
       }
 
-      if (this._peers[id]) {
+      if (this._peers.has(id)) {
         this.emit('warning', new Error(`ignoring duplicate web seed: ${id}`))
         this.emit('invalidPeer', id)
         return
@@ -1143,7 +1151,7 @@ export default class Torrent extends EventEmitter {
       conn = urlOrConn
       id = conn.connId
 
-      if (this._peers[id]) {
+      if (this._peers.has(id)) {
         this.emit('warning', new Error(`ignoring duplicate web seed: ${id}`))
         this.emit('invalidPeer', id)
         return
@@ -1196,13 +1204,13 @@ export default class Torrent extends EventEmitter {
       this.client.emit('upload', uploaded)
     })
 
-    this._peers[newPeer.id] = newPeer
+    this._peers.set(newPeer.id, newPeer)
     this._peersLength += 1
   }
 
   removePeer (peer) {
     const id = peer?.id || peer
-    if (peer && !peer.id) peer = this._peers?.[id]
+    if (peer && !peer.id) peer = this._peers?.get(id)
 
     if (!peer) return
     peer.destroy()
@@ -1211,7 +1219,7 @@ export default class Torrent extends EventEmitter {
 
     this._debug('removePeer %s', id)
 
-    delete this._peers[id]
+    this._peers.delete(id)
     this._peersLength -= 1
 
     // If torrent swarm was at capacity before, try to open a new connection now
@@ -1348,7 +1356,7 @@ export default class Torrent extends EventEmitter {
       wire.ut_pex.on('dropped', peer => {
         // the remote peer believes a given peer has been dropped from the torrent swarm.
         // if we're not currently connected to it, then remove it from the queue.
-        const peerObj = this._peers[peer]
+        const peerObj = this._peers.get(peer)
         if (peerObj && !peerObj.connected) {
           this._debug('ut_pex: dropped peer: %s (from %s)', peer, addr)
           this.removePeer(peer)
@@ -1376,6 +1384,9 @@ export default class Torrent extends EventEmitter {
     }
   }
 
+  /**
+   * @param {import('bittorrent-protocol').default} wire
+   */
   _onWireWithMetadata (wire) {
     let timeoutId = null
 
@@ -1393,9 +1404,12 @@ export default class Torrent extends EventEmitter {
 
     let i
     const updateSeedStatus = () => {
-      if (wire.peerPieces.buffer.length !== this.bitfield.buffer.length) return
-      for (i = 0; i < this.pieces.length; ++i) {
-        if (!wire.peerPieces.get(i)) return
+      // bittorrent-protocol will set use fake bitfield if it gets a have-all message, which means its a seeder
+      if (wire.peerPieces.buffer.length && !!wire.peerPieces.setAll) {
+        if (wire.peerPieces.buffer.length !== this.bitfield.buffer.length) return
+        for (i = 0; i < this.pieces.length; ++i) {
+          if (!wire.peerPieces.get(i)) return
+        }
       }
       wire.isSeeder = true
       if (this.alwaysChokeSeeders) wire.choke() // always choke seeders
@@ -1576,6 +1590,7 @@ export default class Torrent extends EventEmitter {
 
   /**
    * Attempts to update a peer's requests
+   * @param {import('bittorrent-protocol').default} wire
    */
   _updateWire (wire) {
     if (wire.destroyed) return false
@@ -1733,6 +1748,7 @@ export default class Torrent extends EventEmitter {
         } else {
           for (piece = next.from + next.offset; piece <= next.to; piece++) {
             if (!wire.peerPieces.get(piece) || !rank(piece)) continue
+            const requestsBefore = wire.requests.length
 
             while (self._request(wire, piece, self._critical[piece] || hotswap) &&
               wire.requests.length < maxOutstandingRequests) {
@@ -1740,10 +1756,12 @@ export default class Torrent extends EventEmitter {
               // request all non-reserved blocks in piece
             }
 
-            if (wire.requests.length < maxOutstandingRequests) continue
+            if (wire.requests.length >= maxOutstandingRequests) {
+              if (next.priority) shufflePriority(i)
+              return true
+            }
 
-            if (next.priority) shufflePriority(i)
-            return true
+            if (wire.requests.length > requestsBefore) break
           }
         }
       }
@@ -2052,9 +2070,8 @@ export default class Torrent extends EventEmitter {
     this._drain()
   }
 
-  _debug () {
-    const args = [].slice.call(arguments)
-    args[0] = `[${this.client ? this.client._debugId : 'No Client'}] [${this._debugId}] ${args[0]}`
+  _debug (...args) {
+    args[0] = `[${this.client._debugId}] [${this._debugId}] ${args[0]}`
     debug(...args)
   }
 

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "test-browser": "airtap --concurrency 1 --all -- test/*.js test/browser/*.js | tap-spec",
     "test-browser-local": "airtap --preset local -- test/*.js test/browser/*.js | tap-spec",
     "test-node": "tape test/*.js test/node/*.js | tap-spec",
+    "test-single": "tape test/node/client-deselect.js | tap-spec",
     "update-authors": "./scripts/update-authors.sh"
   },
   "renovate": {

--- a/test/node/client-deselect.js
+++ b/test/node/client-deselect.js
@@ -128,14 +128,14 @@ test('client.deselect: multiple overlapping ranges', function (t) {
       torrent.select(12, 18)
       torrent.select(15, 22)
       torrent.select(0, 4)
-      t.assert(torrent._selections.length === 4)
-      assertSelectionsEquals(t, torrent._selections, [[0, 4], [5, 11], [12, 14], [15, 22]])
+      t.assert(torrent._selections.length === 1)
+      assertSelectionsEquals(t, torrent._selections, [[0, 22]])
 
       torrent.deselect(4, 8)
       torrent.deselect(14, 17)
       torrent.deselect(20, 21)
-      t.assert(torrent._selections.length === 5)
-      assertSelectionsEquals(t, torrent._selections, [[0, 3], [9, 11], [12, 13], [18, 19], [22, 22]])
+      t.assert(torrent._selections.length === 4)
+      assertSelectionsEquals(t, torrent._selections, [[0, 3], [9, 13], [18, 19], [22, 22]])
     },
     onIdle: (torrent) => {
       t.equal(torrent.pieces.filter((a) => a === null).length, 12)

--- a/test/selections.js
+++ b/test/selections.js
@@ -71,7 +71,12 @@ test('Selections', (t) => {
         selection = new Selections()
         selection.insert(existing)
         selection.insert(newItem)
-        assertArrayContentsEqual(t, selection._items, [...expectedRemoveResult, newItem])
+        const expected = { from: Infinity, to: 0 }
+        for (const item of [...expectedRemoveResult, newItem]) {
+          expected.from = Math.min(expected.from, item.from)
+          expected.to = Math.max(expected.to, item.to)
+        }
+        assertArrayContentsEqual(t, selection._items, [expected])
         s.end()
       })
     }
@@ -85,7 +90,7 @@ test('Selections', (t) => {
 
     selection.insert({ from: 9, to: 25 })
 
-    assertArrayContentsEqual(t, selection._items, [{ from: 5, to: 8 }, { from: 9, to: 25 }, { from: 26, to: 40 }])
+    assertArrayContentsEqual(t, selection._items, [{ from: 5, to: 40 }])
     s.end()
   })
 })


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
- fixed a problem where seeders weren't being choked and identified as seeders, when LTDonthave extension was used, as bittorrent-tracker used a fake bitfield,  which this code didn't check correctly
- fixed a perf issue when >3k wires were being created, simply JS Objects start performing exponentially worse at >600 entries, and at 3k they become VERY VERY slow, so a map is used, this is somewhat breaking but helps perf a lot
- fixed a problem in the selections add function, which wouldn't concatenate adjacent ranges, which caused problems in the trySelectWire function imploding CPU
- fixed a problem with the default priorities, originally written priorities were delusional and all over the place, even before a lot of the changes, in some places it was 0, false or 1.... now we just don't specify a priority, and use priority 1 for stream selections
- cached num conns as it's called quite agressively, and was quite expensive to iterate it a few thousand times for each call, which happened frequently

selections now behave a little bit differently than before, previously making a selection of 
[1, 10] and [11, 20], would leave 2 selections, now they are merged to [1, 20], reducing the amt of created selections, selections operate on full integers, so there are no (11, 20] ranges, this was a problem in the `_markUnverified` which ran `this.select(index, index)` which then created as many selections as there was pieces.... yikes!
