### PR TITLE
fix: Do not verify pieces which are not contained in any selection

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -19,6 +19,7 @@ export default class File extends EventEmitter {
     this.size = file.length
     this.type = mime.getType(this.name) || 'application/octet-stream'
     this.offset = file.offset
+    this.selected = file.selected || false
 
     this.done = false
 
@@ -86,11 +87,13 @@ export default class File extends EventEmitter {
 
   select (priority) {
     if (this.length === 0) return
+    this.selected = true
     this._torrent.select(this._startPiece, this._endPiece, priority)
   }
 
   deselect () {
     if (this.length === 0) return
+    this.selected = false
     this._torrent.deselect(this._startPiece, this._endPiece)
   }
 

--- a/lib/selections.js
+++ b/lib/selections.js
@@ -141,6 +141,14 @@ export class Selections {
     this._items.length = 0
   }
 
+  contains (index) {
+    for (let i = 0; i < this._items.length; i++) {
+      const s = this._items[i]
+      if (index >= s.from && index <= s.to) return true
+    }
+    return false
+  }
+
   /** @returns {Generator<SelectionItem & {remove: function}>} */
   * [Symbol.iterator] () {
     for (let i = 0; i < this._items.length; i++) {

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -225,7 +225,8 @@ export default class Torrent extends EventEmitter {
         downloaded += (index === len - 1) ? this.lastPieceLength : this.pieceLength
       } else { // "in progress" data
         const piece = this.pieces[index]
-        downloaded += (piece.length - piece.missing)
+        if (piece)
+          downloaded += (piece.length - piece.missing)
       }
     }
     return downloaded
@@ -622,6 +623,8 @@ export default class Torrent extends EventEmitter {
       // start off selecting the entire torrent with low priority
       if (this.pieces.length !== 0 && !this._startAsDeselected) {
         this.select(0, this.pieces.length - 1)
+        // FIXME: Looping through all files is expensive, do this at File creation
+        this.files.map(file => file.selected = true)
       }
     }
 
@@ -638,7 +641,8 @@ export default class Torrent extends EventEmitter {
       : this.pieces.map(() => [])
 
     this.pieces = this.pieces.map((hash, i) => {
-      if (this._hasStartupBitfield && this.bitfield.get(i)) {
+      if (this._hasStartupBitfield && this.bitfield.get(i)
+          || !this._selections.contains(i)) {
         return null
       }
       const pieceLength = (i === this.pieces.length - 1)
@@ -804,6 +808,10 @@ export default class Torrent extends EventEmitter {
    */
   _verifyPiecesUsingHash (pieces, cb) {
     parallelLimit(pieces.map((piece, index) => cb => {
+      if (!this._selections.contains(index)) {
+        cb(null)
+        return
+      }
       const target = Number.isInteger(piece) ? piece : index
       this._verifyPiece(target, (err, isVerified) => {
         if (err) return cb(err)
@@ -832,9 +840,9 @@ export default class Torrent extends EventEmitter {
   }
 
   /**
-   * Verify the hashes of all pieces in the store and update the bitfield for any new valid
-   * pieces. Useful if data has been added to the store outside WebTorrent, e.g. if another
-   * process puts a valid file in the right place. Once the scan is complete,
+   * Verify the hashes of all selected pieces in the store and update the bitfield for any
+   * new valid pieces. Useful if data has been added to the store outside WebTorrent, e.g.
+   * if another process puts a valid file in the right place. Once the scan is complete,
    * `callback(null)` will be called (if provided), unless the torrent was destroyed during
    * the scan, in which case `callback` will be called with an error.
    * @param  {callbackWithError=} cb
@@ -1912,8 +1920,9 @@ export default class Torrent extends EventEmitter {
     const self = this
     const numRequests = wire.requests.length
     const isWebSeed = wire.type === 'webSeed'
+    const piece = self.pieces[index]
 
-    if (self.bitfield.get(index)) return false
+    if (self.bitfield.get(index) || !piece) return false
 
     const maxOutstandingRequests = isWebSeed
       ? Math.min(
@@ -1925,7 +1934,6 @@ export default class Torrent extends EventEmitter {
     if (numRequests >= maxOutstandingRequests) return false
     // var endGame = (wire.requests.length === 0 && self.store.numMissing < 30)
 
-    const piece = self.pieces[index]
     let reservation = isWebSeed ? piece.reserveRemaining() : piece.reserve()
 
     if (reservation === -1 && hotswap && self._hotswap(wire, index)) {
@@ -2013,7 +2021,7 @@ export default class Torrent extends EventEmitter {
 
     // are any new files done?
     this.files.forEach(file => {
-      if (file.done) return
+      if (file.done || !file.selected) return
       for (let i = file._startPiece; i <= file._endPiece; ++i) {
         if (!this.bitfield.get(i)) return
       }
@@ -2023,7 +2031,7 @@ export default class Torrent extends EventEmitter {
     })
 
     // is the torrent done? (if everything is downloaded)
-    const done = this.files.every(file => file.done)
+    const done = this.files.every(file => (file.done || !file.selected))
 
     if (!this.done && done) {
       this.done = true


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Update `_verifyPiecesUsingHash` to only verify pieces that are covered in a selection range. Also update the comment documenting `rescanFiles` to reflect that `rescanFiles` only validates the selected pieces.

**Which issue (if any) does this pull request address?**
When selecting a subset of files to download, the Selections object is initially populated correctly with ranges covering only the needed pieces. However, when file verification is enabled (the default), all pieces will be verified. On initial downloads all of the pieces will fail verification. This causes the `_markUnverified` method to be called for all pieces, which in turn adds selection ranges for all the pieces. Thus all the pieces are selected, even though only a subset was desired.

**Is there anything you'd like reviewers to focus on?**
 From my reading its okay to rely on the selections as a list of pieces that we care about verifying. Am I wrong? Is it appropriate to change the behavior of `rescanFiles`? I think so. If you want to rescan all the files, just select all the files.

Also, I believe this fixes [webtorrent-cli #331](https://github.com/webtorrent/webtorrent-cli/issues/331).