### PR TITLE
Add selectOnly option for torrent creation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -131,6 +131,7 @@ If `opts` is specified, then the default options (shown below) will be overridde
   noPeersIntervalTime: Number, // The amount of time (in seconds) to wait between each check of the `noPeers` event (default=30)
   paused: Boolean,           // If true, create the torrent in a paused state (default=false)
   deselect: Boolean,         // If true, create the torrent with no pieces selected (default=false)
+  selectOnly: String | Array // BEP53 compliant string or Array of integer indices of files to select
   alwaysChokeSeeders: Boolean // If true, client will automatically choke seeders if it's seeding. (default=true)
 }
 ```

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -18,6 +18,7 @@ import MemoryChunkStore from 'memory-chunk-store'
 import joinIterator from 'join-async-iterator'
 import parallel from 'run-parallel'
 import parallelLimit from 'run-parallel-limit'
+import { parse as parseBep53 } from 'bep53-range'
 import parseTorrent, { toMagnetURI, toTorrentFile, remote } from 'parse-torrent'
 import Piece from 'torrent-piece'
 import queueMicrotask from 'queue-microtask'
@@ -67,6 +68,7 @@ import VERSION from '../version.cjs'
  * @property {number|false=} uploads - [default=10]
  * @property {number=} noPeersIntervalTime - The amount of time (in seconds) to wait between each check of the `noPeers` event (default=30)
  * @property {boolean=} deselect - If true, create the torrent with no pieces selected (default=false)
+ * @property {string|Array[number]=} selectOnly - BEP53 compliant string or Array of integer indices of files to select
  * @property {boolean=} paused - If true, create the torrent in a paused state (default=false)
  * @property {Array<number>=} fileModtimes - An array containing a UNIX timestamp indicating the last change for each file of the torrent
  */
@@ -137,6 +139,9 @@ export default class Torrent extends EventEmitter {
     this.store = null
     this.storeOpts = opts.storeOpts
     this.alwaysChokeSeeders = opts.alwaysChokeSeeders ?? true
+    this.selectOnly = (opts.selectOnly !== undefined)
+      ? parseBep53(opts.selectOnly.toString().split(','))
+      : []
 
     this._getAnnounceOpts = opts.getAnnounceOpts
 
@@ -354,9 +359,13 @@ export default class Torrent extends EventEmitter {
       parsedTorrent.urlList = parsedTorrent.urlList.concat(this.urlList)
     }
 
+    // Allow specifying selectOnly via `opts` parameter and remove duplicates
+    parsedTorrent.selectOnly = this.selectOnly.concat(parsedTorrent.selectOnly || [])
+
     // remove duplicates by converting to Set and back
     parsedTorrent.announce = Array.from(new Set(parsedTorrent.announce))
     parsedTorrent.urlList = Array.from(new Set(parsedTorrent.urlList))
+    parsedTorrent.selectOnly = Array.from(new Set(parsedTorrent.selectOnly))
 
     Object.assign(this, parsedTorrent)
 
@@ -611,10 +620,18 @@ export default class Torrent extends EventEmitter {
       rawStore
     )
 
+    // Using the so property is depreciated, this is for backwards compatibility
+    if (Array.isArray(this.so)) {
+      this.selectOnly.concat(this.so)
+      this.selectOnly = Array.from(new Set(this.selectOnly))
+    } else if (!isNaN(Number(this.so))) {
+      this.selectOnly.push(Number(this.so))
+    }
+
     // Select only specified files (BEP53) http://www.bittorrent.org/beps/bep_0053.html
-    if (this.so && !this._startAsDeselected) {
+    if (this.selectOnly.length > 0 && !this._startAsDeselected) {
       this.files.forEach((v, i) => {
-        if (this.so.includes(i)) {
+        if (this.selectOnly.includes(i)) {
           this.files[i].select()
         }
       })


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
This add proper support for selecting a subset of torrent files during creation. It support Arrays and BEP53 compliant strings. Backwards compatibility is kept with applications that used the now depreciated method of setting the `torrent.so` property.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
Are there other places that documentation should be updated? I'm not sure if the `torrent.so` interface was documented (I can't find it). If so, it should be labeled as depreciated.
