### PR TITLE
fix: setting throttleDownload as a float causes error

### DIFF
--- a/index.js
+++ b/index.js
@@ -435,9 +435,9 @@ export default class WebTorrent extends EventEmitter {
    */
   throttleDownload (rate) {
     rate = Number(rate)
-    if (isNaN(rate) || !isFinite(rate) || rate < -1) return false
-    this._downloadLimit = rate
-    if (this._downloadLimit < 0) return this.throttleGroups.down.setEnabled(false)
+    if (isNaN(rate) || !isFinite(rate) || (rate < 0 && rate !== -1)) return false
+    this._downloadLimit = Math.round(rate)
+    if (this._downloadLimit === -1) return this.throttleGroups.down.setEnabled(false)
     this.throttleGroups.down.setEnabled(true)
     this.throttleGroups.down.setRate(this._downloadLimit)
   }
@@ -448,9 +448,9 @@ export default class WebTorrent extends EventEmitter {
    */
   throttleUpload (rate) {
     rate = Number(rate)
-    if (isNaN(rate) || !isFinite(rate) || rate < -1) return false
-    this._uploadLimit = rate
-    if (this._uploadLimit < 0) return this.throttleGroups.up.setEnabled(false)
+    if (isNaN(rate) || !isFinite(rate) || (rate < 0 && rate !== -1)) return false
+    this._uploadLimit = Math.round(rate)
+    if (this._uploadLimit === -1) return this.throttleGroups.up.setEnabled(false)
     this.throttleGroups.up.setEnabled(true)
     this.throttleGroups.up.setRate(this._uploadLimit)
   }


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR updates the implementations of `throttleDownload` and `throttleUpload`:

- The provided `rate` value is now rounded before being passed to `setRate`, preventing float precision errors.
- Stricter validation is applied to the `rate` argument. Previously, any value in the range `[-1, 0)` effectively disabled throttling, but the API specifies that **only** `-1` should disable throttling.

**Which issue (if any) does this pull request address?**

Addresses issue #2958.

**Is there anything you'd like reviewers to focus on?**

What should the expected behavior be when running `client.throttleDownload(1000.01)`?

Should the function:

- Require integer values only and throw an error for floats?  
- Implicitly round float values to the nearest integer (current behavior)?  
- Use another implicit conversion such as floor or ceil?

Feedback on the intended behavior would be helpful.