### PR TITLE
fix: traversal paths validation in getFileModtimes

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -692,8 +692,16 @@ export default class Torrent extends EventEmitter {
    */
   getFileModtimes (cb) {
     const ret = []
+    const rootPath = path.resolve(this.path)
+
     parallelLimit(this.files.map((file, index) => cb => {
-      const filePath = this.addUID ? path.join(this.name + ' - ' + this.infoHash.slice(0, 8)) : path.join(this.path, file.path)
+      const filePath = this.addUID ? path.join(this.name + ' - ' + this.infoHash.slice(0, 8)) : path.resolve(this.path, file.path)
+      const relativePath = path.relative(rootPath, filePath)
+
+      if (!this.addUID && (relativePath === '' || relativePath.startsWith('..') || path.isAbsolute(relativePath))) {
+        return cb(new Error('invalid file path'))
+      }
+
       fs.stat(filePath, (err, stat) => {
         if (err && err.code !== 'ENOENT') return cb(err)
         ret[index] = stat && stat.mtime.getTime()

--- a/test/node/path-traversal.js
+++ b/test/node/path-traversal.js
@@ -1,0 +1,63 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import test from 'tape'
+import WebTorrent from '../../index.js'
+
+test('torrent.getFileModtimes rejects traversal paths outside the download root', t => {
+  t.plan(4)
+
+  const downloadRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'webtorrent-path-traversal-'))
+  const traversalTarget = '../../../etc/hosts'
+
+  const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
+
+  client.on('error', err => {
+    t.fail(err)
+  })
+
+  client.on('warning', err => {
+    t.fail(err)
+  })
+
+  const torrent = client.add({
+    infoHash: '0123456789012345678901234567890123456789',
+    info: Buffer.from('path-traversal-demo'),
+    name: 'malicious_torrent',
+    announce: [],
+    urlList: [],
+    pieceLength: 16384,
+    lastPieceLength: 16,
+    pieces: [Buffer.alloc(20)],
+    length: 16,
+    files: [{
+      name: 'hosts',
+      path: traversalTarget,
+      length: 16,
+      offset: 0
+    }]
+  }, {
+    path: downloadRoot,
+    skipVerify: true
+  })
+
+  torrent.once('ready', () => {
+    torrent.getFileModtimes((err, modtimes) => {
+      t.ok(err instanceof Error)
+      t.equal(err.message, 'invalid file path')
+      t.deepEqual(modtimes, [])
+
+      client.destroy(destroyErr => {
+        t.error(destroyErr, 'client destroyed')
+        fs.rmSync(downloadRoot, { recursive: true, force: true })
+      })
+    })
+  })
+
+  torrent.once('error', err => {
+    t.fail(err)
+    client.destroy(() => {
+      fs.rmSync(downloadRoot, { recursive: true, force: true })
+    })
+  })
+})


### PR DESCRIPTION

## Summary
- Prevent the path traversal in `getFileModtimes()` from  the malicious torrent 


## Verification
- `npx tape test/node/path-traversal.js`
- `npm run test-node`