### PR TITLE
fix: peer churn

### DIFF
--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -258,7 +258,7 @@ export default class Torrent extends EventEmitter {
   }
 
   get _numQueued () {
-    return this._queue.length + (this._peersLength - this._numConns)
+    return this._peersLength - this._numConns
   }
 
   _numConns = 0
@@ -1401,7 +1401,8 @@ export default class Torrent extends EventEmitter {
       if (this.destroyed || wire.destroyed) return
 
       if (this._numQueued > 2 * (this._numConns - this.numPeers) &&
-        wire.amInterested) {
+        this._numConns + this._numPending >= this.client.maxConns &&
+        !(this.done && wire.peerInterested)) {
         wire.destroy()
       } else {
         timeoutId = setTimeout(onChokeTimeout, CHOKE_TIMEOUT)


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
numqueued included queue length, which itself is already part of peerslength, this caused issues, the code for this is over 12 years old and can't be traced to a commit as its part of a deleted repo and package

this caused peers to hang out at ~80 for very long time, and was horrific for initial connection establish

additionally this destroyed peers even when it really shouldn't have as we were well under the peer limits

it destroyed peers that were choking us [preventing from downloading], I assume in hopes they re-add us and unchoke us

---

now it will destroy peers ONLY when there's enough of a queue, and when we're at peer limits, the queue size are required as x2, to prevent rapid swaps on small swarms with small peer counts

while downloading it will destroy wires regardless of type [always peerChoking = true]:
- Uninterested idle: !amInterested, !peerInterested - they have nothing, we give nothing
- Uninterested leecher: !amInterested, peerInterested - **downloading from us but have nothing we need [somewhat of a bad citizen]**
- Interested choked: amInterested, !peerInterested - they have our pieces but won't share
- Interested mutual: amInterested, peerInterested - both want data but they choke us

the amInterested check was removed, as it's more important to download ASAP, to seed later, than to propagate the swarm health during download, notably this only triggers if the queue is massive enough in the first place

while fully downloaded it goes into "seeding mode", and drops:
- !peerInterested, !amChoking - idle, they don't want our data, we don't choke them, wasted slot on both sides
- !peerInterested, amChoking -  idle, we choke them, they don't want our data, they have nothing for us, we're not seeding to them

while keeping:
- peerInterested, amChoking - they want our data but we're choking them, rechoke rotates every 10s, optimistic slot will get to them
_ peerInterested, !amChoking -  actively downloading from us, serving the swarm, keep seeding

---

this pretty much completely solves the issue, peers connect rapidly, churn just as fast, and there are other churn mechanism in the codebase so this can't make us stuck by being "too optimistic":
- PIECE_TIMEOUT (30s, line 1328): destroys wires that accept requests but never deliver pieces
- wire.on('timeout') (line 1320): destroys wires on protocol-level timeout
- KEEP_ALIVE_TIMEOUT (60s): disconnects silent peers
- Rechoke on our side: when _rechoke() chokes a peer, they may choke us back, which triggers onChokeTimeout

---

**Reviewers to address**:
- is there value in being this optimistic, is it simply better to conserve resources and just drop peers that have been choking us for a long while just as before [aka remove the new check for max peer counts]
- is dropping uninterested leechers a good idea for swarm health