### PR TITLE
fix: derive a sensible torrent name when seeding an array of file paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,9 +315,26 @@ export default class WebTorrent extends EventEmitter {
     opts.skipVerify = true
 
     const isFilePath = typeof input === 'string'
+    const isFilePathArray = Array.isArray(input) && input.length > 1 && input.every(item => typeof item === 'string')
 
     // When seeding from fs path, initialize store from that path to avoid a copy
     if (isFilePath) opts.path = path.dirname(input)
+    else if (isFilePathArray && opts.name === undefined) {
+      let commonDir = path.dirname(path.resolve(input[0]))
+
+      for (const filePath of input.slice(1)) {
+        const fileDir = path.dirname(path.resolve(filePath))
+
+        while (commonDir !== path.dirname(commonDir)) {
+          const relativePath = path.relative(commonDir, fileDir)
+          if (relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath)) break
+          commonDir = path.dirname(commonDir)
+        }
+      }
+
+      const name = path.basename(commonDir)
+      if (name) opts.name = name
+    }
     if (!opts.createdBy) opts.createdBy = `WebTorrent/${VERSION_STR}`
 
     const onTorrent = torrent => {

--- a/test/node/seed-array-paths.js
+++ b/test/node/seed-array-paths.js
@@ -1,0 +1,114 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import MemoryChunkStore from 'memory-chunk-store'
+import test from 'tape'
+import WebTorrent from '../../index.js'
+
+const clientOpts = { dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false }
+
+function createClient (t) {
+  const client = new WebTorrent(clientOpts)
+  client.on('error', err => { t.fail(err) })
+  client.on('warning', err => { t.fail(err) })
+  return client
+}
+
+function createFiles (directory, files) {
+  return files.map(file => {
+    const filePath = path.join(directory, file)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, file)
+    return filePath
+  })
+}
+
+test('client.seed: array of filesystem paths uses common parent name', t => {
+  t.plan(3)
+
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'webtorrent-seed-array-'))
+  const input = createFiles(directory, ['index.html', 'package.json'])
+  const client = createClient(t)
+
+  client.seed(input, { announce: [], store: MemoryChunkStore }, torrent => {
+    const name = path.basename(directory)
+    t.equal(torrent.name, name)
+    t.deepEqual(torrent.files.map(file => file.path).sort(), [
+      path.join(name, 'index.html'),
+      path.join(name, 'package.json')
+    ])
+
+    client.destroy(err => {
+      t.error(err, 'client destroyed')
+      fs.rmSync(directory, { recursive: true, force: true })
+    })
+  })
+})
+
+test('client.seed: array of filesystem paths preserves explicit name', t => {
+  t.plan(2)
+
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'webtorrent-seed-array-'))
+  const input = createFiles(directory, ['one.txt', 'two.txt'])
+  const client = createClient(t)
+
+  client.seed(input, { announce: [], name: 'custom-name', store: MemoryChunkStore }, torrent => {
+    t.equal(torrent.name, 'custom-name')
+
+    client.destroy(err => {
+      t.error(err, 'client destroyed')
+      fs.rmSync(directory, { recursive: true, force: true })
+    })
+  })
+})
+
+test('client.seed: single filesystem path keeps file name and store path', t => {
+  t.plan(4)
+
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'webtorrent-seed-array-'))
+  const [input] = createFiles(directory, ['single.txt'])
+  const client = createClient(t)
+
+  client.seed(input, { announce: [] }, torrent => {
+    t.equal(torrent.name, 'single.txt')
+    t.equal(torrent.files[0].path, 'single.txt')
+    t.equal(torrent.path, directory)
+
+    client.destroy(err => {
+      t.error(err, 'client destroyed')
+      fs.rmSync(directory, { recursive: true, force: true })
+    })
+  })
+})
+
+test('client.seed: array of filesystem paths uses deepest common ancestor name', t => {
+  t.plan(2)
+
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'webtorrent-seed-array-'))
+  const input = createFiles(directory, ['first/one.txt', 'second/two.txt'])
+  const client = createClient(t)
+
+  client.seed(input, { announce: [], store: MemoryChunkStore }, torrent => {
+    t.equal(torrent.name, path.basename(directory))
+
+    client.destroy(err => {
+      t.error(err, 'client destroyed')
+      fs.rmSync(directory, { recursive: true, force: true })
+    })
+  })
+})
+
+test('client.seed: array of filesystem paths at root keeps create-torrent fallback', t => {
+  t.plan(2)
+
+  const packagePath = path.resolve('package.json')
+  const hostsPath = process.platform === 'win32'
+    ? path.join(process.env.SystemRoot, 'System32', 'drivers', 'etc', 'hosts')
+    : '/etc/hosts'
+  const client = createClient(t)
+
+  client.seed([packagePath, hostsPath], { announce: [], store: MemoryChunkStore }, torrent => {
+    t.equal(torrent.name, path.basename(packagePath))
+    client.destroy(err => { t.error(err, 'client destroyed') })
+  })
+})


### PR DESCRIPTION
## Summary
Seeding an array of file path strings like `client.seed(['index.html', 'package.json'], ...)` now produces a torrent named after the files' common parent directory instead of the first file's basename, so file paths no longer come out as `index.html/index.html`.

## Why this matters
Reported in #983 and re-validated by a member (ThaUnknown) in October 2024; the issue is labeled `bug` and `accepted`. The root cause is upstream of this repo's control flow: create-torrent's common-prefix detection skips string inputs (its `input.forEach` returns early for strings), so without `opts.name` it falls back to `basename(firstStringPath)`. In a multi-file torrent that name becomes the bencoded `info.name`, i.e. the root folder, which prefixes every file path with the first file's name.

## Changes
- `WebTorrent.seed()` in `index.js` already massages options for single string paths (`opts.path = path.dirname(input)`). This change extends that surface: when the input is an array of more than one path string and the caller passed no `opts.name`, it computes the common parent directory of the resolved paths and sets `opts.name = path.basename(commonDir)` — the same name seeding that folder directly would produce. If no meaningful common directory exists (filesystem root), options are left untouched and the existing create-torrent fallback applies. Caller-supplied `opts.name` and non-string inputs (Buffers, streams, Blobs, FileLists) are unaffected.

## Testing
Added `test/node/seed-array-paths.js`: seeds two fixture paths as an array, asserts the torrent name is the shared parent directory's basename and that file paths inside the torrent are not nested under the first file's name; also covers the explicit `opts.name` override staying intact.

Fixes #983
