### PR TITLE
feat: per torrent download speed limits

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -72,6 +72,8 @@ If `opts` is specified, then the default options (shown below) will be overridde
   blocklist: Array|String, // List of IP's to block
   downloadLimit: Number,   // Max download speed (bytes/sec) over all torrents (default=-1)
   uploadLimit: Number,     // Max upload speed (bytes/sec) over all torrents (default=-1)
+  torrentDownloadLimit: Number, // Default per-torrent download speed limit (bytes/sec) for new torrents (default=-1)
+  torrentUploadLimit: Number,   // Default per-torrent upload speed limit (bytes/sec) for new torrents (default=-1)
   secure: Number           // Enable RC4 encryption (default=1). Allowed values: 0, 1, 2
 }
 ```
@@ -91,10 +93,12 @@ For `opts.natUpnp`, if set to `true`, a temporary mapping is used, if set to `pe
 
 For `opts.seedOutgoingConnections`, if set `true`, outgoing connections will be established while seeding, otherwise, only inbound connections will be responded to.
 
-For `downloadLimit` and `uploadLimit` the possible values can be:
+For `downloadLimit`, `uploadLimit`, `torrentDownloadLimit` and `torrentUploadLimit` the possible values can be:
   - `> 0`. The client will set the throttle at that speed
   - `0`. The client will block any data from being downloaded or uploaded
-  - `-1`. The client will is disable the throttling and use the whole bandwidth available
+  - `-1`. The client will disable the throttling and use the whole bandwidth available
+
+Per-torrent limits are independent of global limits - the effective rate is the minimum of the two.
 
 For `secure` the possible values can be:
   - `0`. RC4 encryption is disabled.
@@ -136,7 +140,9 @@ If `opts` is specified, then the default options (shown below) will be overridde
   noPeersIntervalTime: Number, // The amount of time (in seconds) to wait between each check of the `noPeers` event (default=30)
   paused: Boolean,           // If true, create the torrent in a paused state (default=false)
   deselect: Boolean,         // If true, create the torrent with no pieces selected (default=false)
-  alwaysChokeSeeders: Boolean // If true, client will automatically choke seeders if it's seeding. (default=true)
+  alwaysChokeSeeders: Boolean, // If true, client will automatically choke seeders if it's seeding. (default=true)
+  downloadSpeedLimit: Number, // Per-torrent download speed limit (bytes/sec) over all peers for this torrent (default=-1)
+  uploadSpeedLimit: Number   // Per-torrent upload speed limit (bytes/sec) over all peers for this torrent (default=-1)
 }
 ```
 
@@ -280,6 +286,29 @@ Sets the maximum speed at which the client uploads the torrents, in bytes/sec.
 `rate` must be bigger or equal than zero, or `-1` to disable the upload throttle and
 use the whole bandwidth of the connection.
 
+## `client.throttleTorrentDownload(rate)`
+
+Sets the default per-torrent download throttle rate for all new torrents, and applies it
+to all existing torrents immediately.
+
+`rate` must be bigger or equal than zero, or `-1` to disable the download throttle and
+use the whole bandwidth of the connection.
+
+Per-torrent limits are independent of the global limit set by `client.throttleDownload()`.
+The effective download rate for a torrent is the minimum of its per-torrent limit and the
+global limit.
+
+## `client.throttleTorrentUpload(rate)`
+
+Sets the default per-torrent upload throttle rate for all new torrents, and applies it
+to all existing torrents immediately.
+
+`rate` must be bigger or equal than zero, or `-1` to disable the upload throttle and
+use the whole bandwidth of the connection.
+
+Per-torrent limits are independent of the global limit set by `client.throttleUpload()`.
+The effective upload rate for a torrent is the minimum of its per-torrent limit and the
+global limit.
 
 ## `client.createServer([opts], force)`
 
@@ -507,6 +536,28 @@ The `urlOrConn` argument is either the web seed URL, or an object that provides 
 web seed implementation. A custom conn object is a duplex stream that speaks the bittorrent
 wire protocol and pretends to be a remote peer. It must have a `connId` property that
 uniquely identifies the custom web seed.
+
+## `torrent.throttleDownloadSpeed(rate)`
+
+Sets the per-torrent download throttle rate for this torrent.
+
+`rate` must be bigger or equal than zero, or `-1` to disable the download throttle and
+use the whole bandwidth of the connection.
+
+Per-torrent limits are independent of the global limit set by `client.throttleDownload()`.
+The effective download rate for a torrent is the minimum of its per-torrent limit and the
+global limit.
+
+## `torrent.throttleUploadSpeed(rate)`
+
+Sets the per-torrent upload throttle rate for this torrent.
+
+`rate` must be bigger or equal than zero, or `-1` to disable the upload throttle and
+use the whole bandwidth of the connection.
+
+Per-torrent limits are independent of the global limit set by `client.throttleUpload()`.
+The effective upload rate for a torrent is the minimum of its per-torrent limit and the
+global limit.
 
 ## `torrent.removePeer(peer)`
 

--- a/index.js
+++ b/index.js
@@ -87,6 +87,8 @@ export default class WebTorrent extends EventEmitter {
 
     this._downloadLimit = Math.max((typeof opts.downloadLimit === 'number') ? opts.downloadLimit : -1, -1)
     this._uploadLimit = Math.max((typeof opts.uploadLimit === 'number') ? opts.uploadLimit : -1, -1)
+    this._torrentDownloadLimit = Math.max((typeof opts.torrentDownloadLimit === 'number') ? opts.torrentDownloadLimit : -1, -1)
+    this._torrentUploadLimit = Math.max((typeof opts.torrentUploadLimit === 'number') ? opts.torrentUploadLimit : -1, -1)
 
     if ((this.natUpnp || this.natPmp) && typeof NatAPI === 'function') {
       this.natTraversal = new NatAPI({
@@ -287,6 +289,13 @@ export default class WebTorrent extends EventEmitter {
     this._debug('add')
     opts = opts ? Object.assign({}, opts) : {}
 
+    if (typeof opts.downloadSpeedLimit !== 'number') {
+      opts.downloadSpeedLimit = this._torrentDownloadLimit
+    }
+    if (typeof opts.uploadSpeedLimit !== 'number') {
+      opts.uploadSpeedLimit = this._torrentUploadLimit
+    }
+
     const torrent = new Torrent(torrentId, this, opts)
     this.torrents.push(torrent)
 
@@ -456,6 +465,34 @@ export default class WebTorrent extends EventEmitter {
     if (this._uploadLimit === -1) return this.throttleGroups.up.setEnabled(false)
     this.throttleGroups.up.setEnabled(true)
     this.throttleGroups.up.setRate(this._uploadLimit)
+  }
+
+  /**
+   * Set default per-torrent download throttle rate for all new torrents.
+   * Also applies to all existing torrents.
+   * @param  {Number} rate (must be bigger or equal than zero, or -1 to disable throttling)
+   */
+  throttleTorrentDownload (rate) {
+    rate = Number(rate)
+    if (isNaN(rate) || !isFinite(rate) || (rate < 0 && rate !== -1)) return false
+    this._torrentDownloadLimit = Math.round(rate)
+    for (const torrent of this.torrents) {
+      torrent.throttleDownloadSpeed(this._torrentDownloadLimit)
+    }
+  }
+
+  /**
+   * Set default per-torrent upload throttle rate for all new torrents.
+   * Also applies to all existing torrents.
+   * @param  {Number} rate (must be bigger or equal than zero, or -1 to disable throttling)
+   */
+  throttleTorrentUpload (rate) {
+    rate = Number(rate)
+    if (isNaN(rate) || !isFinite(rate) || (rate < 0 && rate !== -1)) return false
+    this._torrentUploadLimit = Math.round(rate)
+    for (const torrent of this.torrents) {
+      torrent.throttleUploadSpeed(this._torrentUploadLimit)
+    }
   }
 
   /**

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -127,16 +127,17 @@ export default class Peer extends EventEmitter {
     }
   }
 
-  clearPipes () {
-    this.conn.unpipe()
-    this.wire.unpipe()
-  }
-
   setThrottlePipes () {
     const self = this
+
+    const down = this.torrentThrottleGroups.down.throttle()
+    const up = this.torrentThrottleGroups.up.throttle()
+    this._torrentThrottles = { down, up }
+
     pipeline(
       this.conn,
-      this.throttleGroups.down.throttle(),
+      this.clientThrottleGroups.down.throttle(),
+      down,
       new Transform({
         transform (chunk, callback) {
           self.emit('download', chunk.length)
@@ -145,7 +146,8 @@ export default class Peer extends EventEmitter {
         }
       }),
       this.wire,
-      this.throttleGroups.up.throttle(),
+      up,
+      this.clientThrottleGroups.up.throttle(),
       new Transform({
         transform (chunk, callback) {
           self.emit('upload', chunk.length)
@@ -277,11 +279,12 @@ Peer.SOURCE_UT_PEX = SOURCE_UT_PEX
  * "introduction" (i.e. WebRTC signaling), and there's no equivalent to an IP address
  * that lets you refer to a WebRTC endpoint.
  */
-Peer.createWebRTCPeer = (conn, swarm, throttleGroups, source = null) => {
+Peer.createWebRTCPeer = (conn, swarm, torrentThrottleGroups, clientThrottleGroups, source = null) => {
   const peer = new Peer(conn.id, 'webrtc', 0)
   peer.conn = conn
   peer.swarm = swarm
-  peer.throttleGroups = throttleGroups
+  peer.torrentThrottleGroups = torrentThrottleGroups
+  peer.clientThrottleGroups = clientThrottleGroups
   peer.source = source
 
   if (peer.conn.connected) {
@@ -312,8 +315,8 @@ Peer.createWebRTCPeer = (conn, swarm, throttleGroups, source = null) => {
  * listening port of the TCP server. Until the remote peer sends a handshake, we don't
  * know what swarm the connection is intended for.
  */
-Peer.createTCPIncomingPeer = (conn, throttleGroups, secure = 0) => {
-  return Peer._createIncomingPeer(conn, TYPE_TCP_INCOMING, throttleGroups, secure)
+Peer.createTCPIncomingPeer = (conn, clientThrottleGroups, secure = 0) => {
+  return Peer._createIncomingPeer(conn, TYPE_TCP_INCOMING, clientThrottleGroups, clientThrottleGroups, secure)
 }
 
 /**
@@ -321,43 +324,45 @@ Peer.createTCPIncomingPeer = (conn, throttleGroups, secure = 0) => {
  * listening port of the uTP server. Until the remote peer sends a handshake, we don't
  * know what swarm the connection is intended for.
  */
-Peer.createUTPIncomingPeer = (conn, throttleGroups, secure = 0) => {
-  return Peer._createIncomingPeer(conn, TYPE_UTP_INCOMING, throttleGroups, secure)
+Peer.createUTPIncomingPeer = (conn, clientThrottleGroups, secure = 0) => {
+  return Peer._createIncomingPeer(conn, TYPE_UTP_INCOMING, clientThrottleGroups, clientThrottleGroups, secure)
 }
 
 /**
  * Outgoing TCP peers start out with just an IP address. At some point (when there is an
  * available connection), the client can attempt to connect to the address.
  */
-Peer.createTCPOutgoingPeer = (addr, swarm, throttleGroups, source, secure = 0) => {
-  return Peer._createOutgoingPeer(addr, swarm, TYPE_TCP_OUTGOING, throttleGroups, source, secure)
+Peer.createTCPOutgoingPeer = (addr, swarm, torrentThrottleGroups, clientThrottleGroups, source = null, secure = 0) => {
+  return Peer._createOutgoingPeer(addr, swarm, TYPE_TCP_OUTGOING, torrentThrottleGroups, clientThrottleGroups, source, secure)
 }
 
 /**
  * Outgoing uTP peers start out with just an IP address. At some point (when there is an
  * available connection), the client can attempt to connect to the address.
  */
-Peer.createUTPOutgoingPeer = (addr, swarm, throttleGroups, source, secure = 0) => {
-  return Peer._createOutgoingPeer(addr, swarm, TYPE_UTP_OUTGOING, throttleGroups, source, secure)
+Peer.createUTPOutgoingPeer = (addr, swarm, torrentThrottleGroups, clientThrottleGroups, source = null, secure = 0) => {
+  return Peer._createOutgoingPeer(addr, swarm, TYPE_UTP_OUTGOING, torrentThrottleGroups, clientThrottleGroups, source, secure)
 }
 
-Peer._createIncomingPeer = (conn, type, throttleGroups, secure = 0) => {
+Peer._createIncomingPeer = (conn, type, torrentThrottleGroups, clientThrottleGroups, secure = 0) => {
   const addr = `${conn.remoteAddress}:${conn.remotePort}`
   const peer = new Peer(addr, type, secure)
   peer.conn = conn
   peer.addr = addr
-  peer.throttleGroups = throttleGroups
+  peer.torrentThrottleGroups = torrentThrottleGroups
+  peer.clientThrottleGroups = clientThrottleGroups
 
   peer.onConnect()
 
   return peer
 }
 
-Peer._createOutgoingPeer = (addr, swarm, type, throttleGroups, source = null, secure = 0) => {
+Peer._createOutgoingPeer = (addr, swarm, type, torrentThrottleGroups, clientThrottleGroups, source = null, secure = 0) => {
   const peer = new Peer(addr, type, secure)
   peer.addr = addr
   peer.swarm = swarm
-  peer.throttleGroups = throttleGroups
+  peer.torrentThrottleGroups = torrentThrottleGroups
+  peer.clientThrottleGroups = clientThrottleGroups
   peer.source = source
 
   return peer
@@ -367,12 +372,13 @@ Peer._createOutgoingPeer = (addr, swarm, type, throttleGroups, source = null, se
  * Peer that represents a Web Seed (BEP17 / BEP19).
  */
 
-Peer.createWebSeedPeer = (conn, id, swarm, throttleGroups) => {
+Peer.createWebSeedPeer = (conn, id, swarm, torrentThrottleGroups, clientThrottleGroups) => {
   const peer = new Peer(id, TYPE_WEBSEED, 0)
 
   peer.swarm = swarm
   peer.conn = conn
-  peer.throttleGroups = throttleGroups
+  peer.torrentThrottleGroups = torrentThrottleGroups
+  peer.clientThrottleGroups = clientThrottleGroups
 
   peer.onConnect()
 

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -24,6 +24,7 @@ import once from 'once'
 import queueMicrotask from 'queue-microtask'
 import randomIterate from 'random-iterate'
 import { hash } from 'uint8-util'
+import { ThrottleGroup } from 'speed-limiter'
 import throughput from 'throughput'
 import utMetadata from 'ut_metadata'
 import utPex from 'ut_pex' // browser exclude
@@ -68,6 +69,8 @@ import { Selections } from './selections.js'
  * @property {boolean=} deselect - If true, create the torrent with no pieces selected (default=false)
  * @property {boolean=} paused - If true, create the torrent in a paused state (default=false)
  * @property {Array<number>=} fileModtimes - An array containing a UNIX timestamp indicating the last change for each file of the torrent
+ * @property {number=} downloadSpeedLimit - Per-torrent download speed limit (bytes/s), or -1 to disable (default=no limit)
+ * @property {number=} uploadSpeedLimit - Per-torrent upload speed limit (bytes/s), or -1 to disable (default=no limit)
  */
 
 // End of JSDoc global declarations
@@ -141,6 +144,18 @@ export default class Torrent extends EventEmitter {
     if (typeof opts.private === 'boolean') this.private = opts.private
 
     this.strategy = opts.strategy || 'sequential'
+
+    this._downloadSpeedLimit = Math.max(
+      (typeof opts.downloadSpeedLimit === 'number') ? opts.downloadSpeedLimit : -1, -1
+    )
+    this._uploadSpeedLimit = Math.max(
+      (typeof opts.uploadSpeedLimit === 'number') ? opts.uploadSpeedLimit : -1, -1
+    )
+
+    this.throttleGroups = {
+      down: new ThrottleGroup({ rate: Math.max(this._downloadSpeedLimit, 0), enabled: this._downloadSpeedLimit >= 0 }),
+      up: new ThrottleGroup({ rate: Math.max(this._uploadSpeedLimit, 0), enabled: this._uploadSpeedLimit >= 0 })
+    }
 
     this.maxWebConns = opts.maxWebConns || 4
 
@@ -1102,11 +1117,11 @@ export default class Torrent extends EventEmitter {
     if (typeof peer === 'string') {
       // `peer` is an addr ("ip:port" string)
       newPeer = type === 'utp'
-        ? Peer.createUTPOutgoingPeer(peer, this, this.client.throttleGroups, source, this.client.secure)
-        : Peer.createTCPOutgoingPeer(peer, this, this.client.throttleGroups, source, this.client.secure)
+        ? Peer.createUTPOutgoingPeer(peer, this, this.throttleGroups, this.client.throttleGroups, source, this.client.secure)
+        : Peer.createTCPOutgoingPeer(peer, this, this.throttleGroups, this.client.throttleGroups, source, this.client.secure)
     } else {
       // `peer` is a WebRTC connection (simple-peer)
-      newPeer = Peer.createWebRTCPeer(peer, this, this.client.throttleGroups, source)
+      newPeer = Peer.createWebRTCPeer(peer, this, this.throttleGroups, this.client.throttleGroups, source)
     }
 
     this._registerPeer(newPeer)
@@ -1157,7 +1172,7 @@ export default class Torrent extends EventEmitter {
 
     this._debug('add web seed %s', id)
 
-    const newPeer = Peer.createWebSeedPeer(conn, id, this, this.client.throttleGroups)
+    const newPeer = Peer.createWebSeedPeer(conn, id, this, this.throttleGroups, this.client.throttleGroups)
 
     this._registerPeer(newPeer)
 
@@ -1173,6 +1188,9 @@ export default class Torrent extends EventEmitter {
     if (this.paused) return peer.destroy(new Error('torrent is paused'))
 
     this._debug('add incoming peer %s', peer.id)
+
+    peer._torrentThrottles.down._group = this.throttleGroups.down
+    peer._torrentThrottles.up._group = this.throttleGroups.up
 
     this._registerPeer(peer)
   }
@@ -2086,6 +2104,32 @@ export default class Torrent extends EventEmitter {
     this._debug('resume')
     this.paused = false
     this._drain()
+  }
+
+  /**
+   * Set per-torrent download throttle rate.
+   * @param  {Number} rate (must be bigger or equal than zero, or -1 to disable throttling)
+   */
+  throttleDownloadSpeed (rate) {
+    rate = Number(rate)
+    if (isNaN(rate) || !isFinite(rate) || (rate < 0 && rate !== -1)) return false
+    this._downloadSpeedLimit = Math.round(rate)
+    if (this._downloadSpeedLimit === -1) return this.throttleGroups.down.setEnabled(false)
+    this.throttleGroups.down.setEnabled(true)
+    this.throttleGroups.down.setRate(this._downloadSpeedLimit)
+  }
+
+  /**
+   * Set per-torrent upload throttle rate.
+   * @param  {Number} rate (must be bigger or equal than zero, or -1 to disable throttling)
+   */
+  throttleUploadSpeed (rate) {
+    rate = Number(rate)
+    if (isNaN(rate) || !isFinite(rate) || (rate < 0 && rate !== -1)) return false
+    this._uploadSpeedLimit = Math.round(rate)
+    if (this._uploadSpeedLimit === -1) return this.throttleGroups.up.setEnabled(false)
+    this.throttleGroups.up.setEnabled(true)
+    this.throttleGroups.up.setRate(this._uploadSpeedLimit)
   }
 
   _debug (...args) {

--- a/test/node/limit-torrent.js
+++ b/test/node/limit-torrent.js
@@ -1,0 +1,139 @@
+import fixtures from 'webtorrent-fixtures'
+import test from 'tape'
+import MemoryChunkStore from 'memory-chunk-store'
+import WebTorrent from '../../index.js'
+
+const UPLOAD_SPEED_LIMIT = 200 * 1000 // 200 KB/s
+
+function testSpeed (t, downloaderOpts, uploaderOpts, cb) {
+  const client1 = new WebTorrent({ dht: false, tracker: false, ...downloaderOpts })
+  const client2 = new WebTorrent({ dht: false, tracker: false, ...uploaderOpts })
+
+  client1.on('error', err => { t.fail(err) })
+  client1.on('warning', err => { t.fail(err) })
+
+  client2.on('error', err => { t.fail(err) })
+  client2.on('warning', err => { t.fail(err) })
+
+  const downloadSpeeds = []
+  const uploadSpeeds = []
+
+  // Start seeding
+  client2.seed(fixtures.leaves.content, {
+    name: 'Leaves of Grass by Walt Whitman.epub',
+    announce: []
+  }, torrent => {
+    torrent.on('upload', () => {
+      uploadSpeeds.push(torrent.uploadSpeed)
+    })
+  })
+
+  client2.on('listening', () => {
+    // Start downloading
+    const torrent = client1.add(fixtures.leaves.parsedTorrent.infoHash, { store: MemoryChunkStore })
+
+    torrent.once('infoHash', () => {
+      // Manually connect peers
+      torrent.addPeer(`127.0.0.1:${client2.address().port}`)
+    })
+
+    torrent.on('download', () => {
+      downloadSpeeds.push(torrent.downloadSpeed)
+    })
+
+    torrent.on('done', () => {
+      cb(downloadSpeeds, uploadSpeeds)
+
+      client1.destroy(err => { t.error(err, 'client 1 destroyed') })
+      client2.destroy(err => { t.error(err, 'client 2 destroyed') })
+    })
+  })
+}
+
+test('Limit per-torrent upload speed by client constructor option when tcp connection', t => {
+  t.plan(3)
+
+  testSpeed(t, {}, { torrentUploadLimit: UPLOAD_SPEED_LIMIT }, (_, uploadSpeeds) => {
+    t.ok(uploadSpeeds.every(uploadSpeed => uploadSpeed <= UPLOAD_SPEED_LIMIT))
+  })
+})
+
+test('Limit per-torrent upload speed by client throttleTorrentUpload method when tcp connection', t => {
+  t.plan(3)
+
+  const client1 = new WebTorrent({ dht: false, tracker: false })
+  const client2 = new WebTorrent({ dht: false, tracker: false })
+  client2.throttleTorrentUpload(UPLOAD_SPEED_LIMIT)
+
+  client1.on('error', err => { t.fail(err) })
+  client1.on('warning', err => { t.fail(err) })
+
+  client2.on('error', err => { t.fail(err) })
+  client2.on('warning', err => { t.fail(err) })
+
+  const uploadSpeeds = []
+
+  client2.seed(fixtures.leaves.content, {
+    name: 'Leaves of Grass by Walt Whitman.epub',
+    announce: []
+  }, torrent => {
+    torrent.on('upload', () => {
+      uploadSpeeds.push(torrent.uploadSpeed)
+    })
+  })
+
+  client2.on('listening', () => {
+    const torrent = client1.add(fixtures.leaves.parsedTorrent.infoHash, { store: MemoryChunkStore })
+
+    torrent.once('infoHash', () => {
+      torrent.addPeer(`127.0.0.1:${client2.address().port}`)
+    })
+
+    torrent.on('done', () => {
+      t.ok(uploadSpeeds.every(uploadSpeed => uploadSpeed <= UPLOAD_SPEED_LIMIT))
+
+      client1.destroy(err => { t.error(err, 'client 1 destroyed') })
+      client2.destroy(err => { t.error(err, 'client 2 destroyed') })
+    })
+  })
+})
+
+test('Limit per-torrent upload speed by torrent throttleUploadSpeed method when tcp connection', t => {
+  t.plan(3)
+
+  const client1 = new WebTorrent({ dht: false, tracker: false })
+  const client2 = new WebTorrent({ dht: false, tracker: false })
+
+  client1.on('error', err => { t.fail(err) })
+  client1.on('warning', err => { t.fail(err) })
+
+  client2.on('error', err => { t.fail(err) })
+  client2.on('warning', err => { t.fail(err) })
+
+  const uploadSpeeds = []
+
+  client2.seed(fixtures.leaves.content, {
+    name: 'Leaves of Grass by Walt Whitman.epub',
+    announce: []
+  }, torrent => {
+    torrent.throttleUploadSpeed(UPLOAD_SPEED_LIMIT)
+    torrent.on('upload', () => {
+      uploadSpeeds.push(torrent.uploadSpeed)
+    })
+  })
+
+  client2.on('listening', () => {
+    const torrent = client1.add(fixtures.leaves.parsedTorrent.infoHash, { store: MemoryChunkStore })
+
+    torrent.once('infoHash', () => {
+      torrent.addPeer(`127.0.0.1:${client2.address().port}`)
+    })
+
+    torrent.on('done', () => {
+      t.ok(uploadSpeeds.every(uploadSpeed => uploadSpeed <= UPLOAD_SPEED_LIMIT))
+
+      client1.destroy(err => { t.error(err, 'client 1 destroyed') })
+      client2.destroy(err => { t.error(err, 'client 2 destroyed') })
+    })
+  })
+})


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Added per torrent download speed limits. This is 90% a copy-paste of the global speed limits code
**Which issue (if any) does this pull request address?**
The only notable thing is the incoming peer connections, it's quite hacky, as it sets the throttle for torrent as the client one, then swaps it after the infoHash is emitted.

This is pretty much the only way, as incoming peer connections don't have an infohash yet [duh], and since streamx doesnt implement unpipe, we can't re-create the pipeline.
**Is there anything you'd like reviewers to focus on?**
Tests