### PR TITLE
feat: priority based connection budget

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -58,6 +58,7 @@ If `opts` is specified, then the default options (shown below) will be overridde
 ```js
 {
   maxConns: Number,        // Max number of connections per torrent (default=55)
+  connectionBudget: Number,  // Connection budget target across all torrents (default=200)
   nodeId: String|Uint8Array,   // DHT protocol node ID (default=randomly generated)
   peerId: String|Uint8Array,   // Wire protocol peer ID (default=randomly generated)
   tracker: Boolean|Object, // Enable trackers (default=true), or options object for Tracker
@@ -95,6 +96,10 @@ For `downloadLimit` and `uploadLimit` the possible values can be:
   - `> 0`. The client will set the throttle at that speed
   - `0`. The client will block any data from being downloaded or uploaded
   - `-1`. The client will is disable the throttling and use the whole bandwidth available
+
+`connectionBudget` is a priority-based connection budget target across all torrents. Not a hard cap, when the budget is fully utilized, torrents at or above their fair share are limited, leaving room for others to catch up.
+
+Each priority point gets a base allocation (`connectionBudget / totalPriority`, minimum 1). A priority-3 torrent always gets 3x the slots of a priority-1 torrent.
 
 For `secure` the possible values can be:
   - `0`. RC4 encryption is disabled.
@@ -136,7 +141,8 @@ If `opts` is specified, then the default options (shown below) will be overridde
   noPeersIntervalTime: Number, // The amount of time (in seconds) to wait between each check of the `noPeers` event (default=30)
   paused: Boolean,           // If true, create the torrent in a paused state (default=false)
   deselect: Boolean,         // If true, create the torrent with no pieces selected (default=false)
-  alwaysChokeSeeders: Boolean // If true, client will automatically choke seeders if it's seeding. (default=true)
+  alwaysChokeSeeders: Boolean, // If true, client will automatically choke seeders if it's seeding. (default=true)
+  priority: Number           // Torrent priority for connection budget allocation (default=1, higher = preferred)
 }
 ```
 
@@ -480,6 +486,17 @@ If truthy, `store.destroy()` will be called, which will delete the torrent's fil
 
 If `callback` is provided, it will be called when the torrent is fully destroyed,
 i.e. all open sockets are closed, and the storage is either closed or destroyed.
+
+## `torrent.setPriority(priority)`
+
+Sets the torrent's priority (minimum `1`). The connection budget target (`connectionBudget`)
+is shared across all torrents based on priority — a priority-3 torrent always gets 3x the
+target of a priority-1 torrent. Targets are recalculated immediately when priorities change
+or torrents are added/removed.
+
+The budget is a target, not a hard cap. Torrents never lose existing peers when their target
+shrinks; they simply stop accepting new ones until peers disconnect naturally. The per-torrent
+`maxConns` still applies as an absolute upper bound.
 
 ## `torrent.addPeer(peer)`
 

--- a/index.js
+++ b/index.js
@@ -82,11 +82,15 @@ export default class WebTorrent extends EventEmitter {
     this.natPmp = opts.natPmp ?? true
     this.torrents = []
     this.maxConns = Number(opts.maxConns) || 55
+    this.connectionBudget = Number(opts.connectionBudget) || 500
     this.utp = WebTorrent.UTP_SUPPORT && opts.utp !== false
     this.seedOutgoingConnections = opts.seedOutgoingConnections ?? true
 
     this._downloadLimit = Math.max((typeof opts.downloadLimit === 'number') ? opts.downloadLimit : -1, -1)
     this._uploadLimit = Math.max((typeof opts.uploadLimit === 'number') ? opts.uploadLimit : -1, -1)
+
+    this._ipObservations = {}
+    this._bestLocalIP = null
 
     if ((this.natUpnp || this.natPmp) && typeof NatAPI === 'function') {
       this.natTraversal = new NatAPI({
@@ -458,6 +462,22 @@ export default class WebTorrent extends EventEmitter {
     this.throttleGroups.up.setRate(this._uploadLimit)
   }
 
+  get _totalConns () {
+    let total = 0
+    for (const t of this.torrents) {
+      if (!t.destroyed) total += t._numConns
+    }
+    return total
+  }
+
+  get _totalPending () {
+    let total = 0
+    for (const t of this.torrents) {
+      if (!t.destroyed) total += t._numPending
+    }
+    return total
+  }
+
   /**
    * Destroy the client, including all torrents and connections to peers.
    * @param  {function} cb
@@ -530,11 +550,25 @@ export default class WebTorrent extends EventEmitter {
           }).catch(err => {
             debug('error mapping WebTorrent port via UPnP/PMP: %o', err)
           })
+          this.natTraversal.externalIp().then(ip => this._recordIP(ip)).catch(() => {})
         }
       }
     }
 
     this.emit('listening')
+  }
+
+  /**
+   * @param  {string=} ip
+   */
+  _recordIP (ip) {
+    if (!ip || typeof ip !== 'string') return
+    const count = (this._ipObservations[ip] || 0) + 1
+    this._ipObservations[ip] = count
+    if (!this._bestLocalIP || count > this._ipObservations[this._bestLocalIP]) {
+      this._bestLocalIP = ip
+    }
+    return this._bestLocalIP
   }
 
   _debug () {

--- a/lib/bep40.js
+++ b/lib/bep40.js
@@ -1,0 +1,149 @@
+import { and, compare, equal } from 'uint8-util'
+
+const TABLE = new Uint32Array(256)
+for (let i = 0; i < 256; i++) {
+  let c = i
+  for (let j = 0; j < 8; j++) {
+    c = (c & 1) ? (0x82F63B78 ^ (c >>> 1)) : (c >>> 1)
+  }
+  TABLE[i] = c
+}
+
+export function crc32c (data) {
+  let crc = 0xFFFFFFFF
+  for (let i = 0; i < data.length; i++) {
+    crc = TABLE[(crc ^ data[i]) & 0xFF] ^ (crc >>> 8)
+  }
+  return (crc ^ 0xFFFFFFFF) >>> 0
+}
+
+function demoteIPv4Mapped (bytes) {
+  if (bytes.length !== 16) return bytes
+  for (let i = 0; i < 10; i++) {
+    if (bytes[i] !== 0) return bytes
+  }
+  if (bytes[10] !== 0xFF || bytes[11] !== 0xFF) return bytes
+  return bytes.subarray(12)
+}
+
+function parseIPv4 (ip) {
+  return new Uint8Array(ip.split('.').slice(0, 4))
+}
+
+function parseIPv6 (ip) {
+  ip = ip.replace(/^\[|\]$/g, '')
+
+  if (ip.includes('.') && ip.includes(':')) {
+    const lastColon = ip.lastIndexOf(':')
+    const buf = new Uint8Array(16)
+    buf[10] = 0xFF
+    buf[11] = 0xFF
+    buf.set(parseIPv4(ip.substring(lastColon + 1)), 12)
+    return buf
+  }
+
+  const buf = new Uint8Array(16)
+  const parts = ip.split(':')
+
+  const emptyIdx = parts.indexOf('')
+  if (emptyIdx === -1) {
+    for (let i = 0; i < 8; i++) {
+      const val = parseInt(parts[i], 16)
+      buf[i * 2] = val >> 8
+      buf[i * 2 + 1] = val & 0xFF
+    }
+  } else {
+    const numBefore = emptyIdx
+    const numAfter = parts.length - emptyIdx - 1
+    const zeroGroups = 8 - numBefore - numAfter
+
+    for (let i = 0; i < numBefore; i++) {
+      const val = parseInt(parts[i], 16)
+      buf[i * 2] = val >> 8
+      buf[i * 2 + 1] = val & 0xFF
+    }
+
+    for (let i = 0; i < numAfter; i++) {
+      const val = parseInt(parts[emptyIdx + 1 + i], 16)
+      const offset = (numBefore + zeroGroups + i) * 2
+      buf[offset] = val >> 8
+      buf[offset + 1] = val & 0xFF
+    }
+  }
+
+  return buf
+}
+
+export function bytesToIP (bytes) {
+  if (bytes.length === 4) return bytes.join('.')
+
+  const demoted = demoteIPv4Mapped(bytes)
+  if (demoted !== bytes) return demoted.join('.')
+
+  const parts = []
+  for (let i = 0; i < 16; i += 2) {
+    parts.push(((bytes[i] << 8) + bytes[i + 1]).toString(16))
+  }
+  return parts.join(':')
+}
+
+export function ipToBytes (ip) {
+  return ip.includes(':') ? parseIPv6(ip) : parseIPv4(ip)
+}
+
+function getIPv4Mask (a, b) {
+  if (a[0] === b[0] && a[1] === b[1] && a[2] === b[2]) return new Uint8Array([0xFF, 0xFF, 0xFF, 0xFF])
+  if (a[0] === b[0] && a[1] === b[1]) return new Uint8Array([0xFF, 0xFF, 0xFF, 0x55])
+  return new Uint8Array([0xFF, 0xFF, 0x55, 0x55])
+}
+
+function getIPv6Mask (a, b) {
+  let same = 0
+  while (same < 16 && a[same] === b[same]) same++
+  const prefix = same >= 7 ? 8 : same >= 6 ? 7 : 6
+  const mask = new Uint8Array(16)
+  for (let i = 0; i < prefix; i++) mask[i] = 0xFF
+  for (let i = prefix; i < 16; i++) mask[i] = 0x55
+  return mask
+}
+
+function mapIPv4ToIPv6 (bytes) {
+  const mapped = new Uint8Array(16)
+  mapped[10] = 0xFF
+  mapped[11] = 0xFF
+  mapped.set(bytes, 12)
+  return mapped
+}
+
+export function computePriority (localIP, localPort, remoteIP, remotePort) {
+  let localBytes = demoteIPv4Mapped(ipToBytes(localIP))
+  let remoteBytes = demoteIPv4Mapped(ipToBytes(remoteIP))
+
+  if (equal(localBytes, remoteBytes)) {
+    const low = localPort <= remotePort ? localPort : remotePort
+    const high = localPort <= remotePort ? remotePort : localPort
+    return crc32c(new Uint8Array([low >> 8, low & 0xFF, high >> 8, high & 0xFF]))
+  }
+
+  if (localBytes.length !== remoteBytes.length) {
+    if (localBytes.length === 4) localBytes = mapIPv4ToIPv6(localBytes)
+    else remoteBytes = mapIPv4ToIPv6(remoteBytes)
+  }
+
+  const isV4 = localBytes.length === 4
+  const mask = isV4 ? getIPv4Mask(localBytes, remoteBytes) : getIPv6Mask(localBytes, remoteBytes)
+  const maskedLocal = and(localBytes, mask)
+  const maskedRemote = and(remoteBytes, mask)
+
+  const len = localBytes.length
+  const buf = new Uint8Array(len * 2)
+  if (compare(maskedLocal, maskedRemote) <= 0) {
+    buf.set(maskedLocal)
+    buf.set(maskedRemote, len)
+  } else {
+    buf.set(maskedRemote)
+    buf.set(maskedLocal, len)
+  }
+
+  return crc32c(buf)
+}

--- a/lib/peer.js
+++ b/lib/peer.js
@@ -3,6 +3,8 @@ import { Transform, pipeline } from 'streamx'
 import arrayRemove from 'unordered-array-remove'
 import debugFactory from 'debug'
 import Wire from 'bittorrent-protocol'
+import addrToIPPort from 'addr-to-ip-port'
+import { computePriority, bytesToIP, ipToBytes } from './bep40.js'
 
 const CONNECT_TIMEOUT_TCP = 5_000
 const CONNECT_TIMEOUT_UTP = 5_000
@@ -48,6 +50,7 @@ export default class Peer extends EventEmitter {
     this.swarm = null
     this.wire = null
     this.source = null
+    this.bep40Priority = 0
 
     this.connected = false
     this.destroyed = false
@@ -55,6 +58,26 @@ export default class Peer extends EventEmitter {
     this.retries = 0 // outgoing TCP connection retry count
 
     this.sentHandshake = false
+  }
+
+  /**
+   * Computes BEP40 priority from current state.
+   *
+   * For connected peers uses socket addresses; for queued outgoing peers
+   * uses the best-known local IP from client-level observations and parses
+   * the target address. WebSeed peers always get Infinity.
+   */
+  _computeBEP40Priority () {
+    if (this.bep40Priority || this.destroyed) return
+
+    // public IP, local IP, internal IP, support them all
+    const localIp = this.swarm?.client?._bestLocalIP || this.conn?.localAddress || '0.0.0.0'
+    const localPort = this.swarm?.client?.torrentPort || this.conn?.localPort || 0
+    const [remoteIp, remotePort] = this.addr ? addrToIPPort(this.addr) : [this.conn.remoteAddress, this.conn.remotePort]
+
+    if (!remoteIp || !remotePort) return
+
+    this.bep40Priority = computePriority(localIp, localPort, remoteIp, remotePort)
   }
 
   /**
@@ -113,6 +136,23 @@ export default class Peer extends EventEmitter {
     this.startHandshakeTimeout()
 
     this.setThrottlePipes()
+
+    if (!this.addr && conn.remoteAddress && conn.remotePort) {
+      this.addr = `${conn.remoteAddress}:${conn.remotePort}`
+    }
+
+    this._computeBEP40Priority()
+
+    // Observe the remote's `yourip` extended handshake field to learn our
+    // observed IP, then compute BEP40 priority with the refined IP.
+    wire.on('extended', (type, handshake) => {
+      if (type !== 'handshake') return
+      if (!this.wire || !this.conn || this.destroyed) return
+      if (handshake.yourip) {
+        this.swarm?.client?._recordIP(bytesToIP(handshake.yourip))
+        this._computeBEP40Priority()
+      }
+    })
 
     if (this.swarm) {
       if (this.type.includes('Outgoing')) {
@@ -184,11 +224,7 @@ export default class Peer extends EventEmitter {
 
     this.retries = 0
 
-    let addr = this.addr
-    if (!addr && this.conn.remoteAddress && this.conn.remotePort) {
-      addr = `${this.conn.remoteAddress}:${this.conn.remotePort}`
-    }
-    this.swarm._onWire(this.wire, addr)
+    this.swarm._onWire(this.wire, this.addr)
 
     // swarm could be destroyed in user's 'wire' event handler
     if (!this.swarm || this.swarm.destroyed) return
@@ -201,6 +237,8 @@ export default class Peer extends EventEmitter {
       dht: this.swarm.private ? false : !!this.swarm.client.dht,
       fast: true
     }
+    // webseed peers don't have this!
+    if (this.addr) this.wire.extendedHandshake.yourip = ipToBytes(addrToIPPort(this.addr)[0])
     this.wire.handshake(this.swarm.infoHash, this.swarm.client.peerId, opts)
     this.sentHandshake = true
   }
@@ -360,6 +398,8 @@ Peer._createOutgoingPeer = (addr, swarm, type, throttleGroups, source = null, se
   peer.throttleGroups = throttleGroups
   peer.source = source
 
+  peer._computeBEP40Priority()
+
   return peer
 }
 
@@ -369,6 +409,7 @@ Peer._createOutgoingPeer = (addr, swarm, type, throttleGroups, source = null, se
 
 Peer.createWebSeedPeer = (conn, id, swarm, throttleGroups) => {
   const peer = new Peer(id, TYPE_WEBSEED, 0)
+  peer.bep40Priority = Infinity
 
   peer.swarm = swarm
   peer.conn = conn

--- a/lib/torrent.js
+++ b/lib/torrent.js
@@ -34,6 +34,7 @@ import RarityMap from './rarity-map.js'
 import utp from './utp.cjs' // browser exclude
 import WebConn from './webconn.js'
 import { Selections } from './selections.js'
+import { bytesToIP } from './bep40.js'
 
 // The following JSDoc comments are global types that can be used across the project
 
@@ -64,6 +65,7 @@ import { Selections } from './selections.js'
  * @property {'rarest'|'sequential'=} strategy - Piece selection strategy, `rarest` or `sequential`(defaut=`sequential`)
  * @property {number=} maxWebConns - Max number of simultaneous connections per web seed [default=4]
  * @property {number|false=} uploads - [default=10]
+ * @property {number=} priority - Torrent priority for connection budget allocation (default=1, higher = preferred)
  * @property {number=} noPeersIntervalTime - The amount of time (in seconds) to wait between each check of the `noPeers` event (default=30)
  * @property {boolean=} deselect - If true, create the torrent with no pieces selected (default=false)
  * @property {boolean=} paused - If true, create the torrent in a paused state (default=false)
@@ -142,6 +144,7 @@ export default class Torrent extends EventEmitter {
 
     this.strategy = opts.strategy || 'sequential'
 
+    this.priority = Math.max(1, Math.round(opts.priority || 1) || 1)
     this.maxWebConns = opts.maxWebConns || 4
 
     this._rechokeNumSlots = (opts.uploads === false || opts.uploads === 0)
@@ -251,6 +254,17 @@ export default class Torrent extends EventEmitter {
   get ratio () { return this.uploaded / (this.received || this.length) }
 
   get numPeers () { return this.wires.length }
+
+  // Priority-based share of the connection budget target.
+  // Not a hard cap, when the budget is fully utilized, torrents at or above
+  // their target stop accepting new connections, leaving room for others.
+  get _fairShare () {
+    if (this.destroyed || !this.client) return 0
+    const totalWeight = this.client.torrents
+      .reduce((sum, t) => t.destroyed ? sum : sum + t.priority * t.priority, 0)
+    if (totalWeight === 0) return Infinity
+    return Math.ceil(this.client.connectionBudget * this.priority * this.priority / totalWeight)
+  }
 
   get torrentFileBlob () {
     if (!this.torrentFile) return null
@@ -437,6 +451,16 @@ export default class Torrent extends EventEmitter {
     this.discovery.on('trackerAnnounce', () => {
       this.emit('trackerAnnounce')
     })
+
+    if (this.discovery.tracker) {
+      this.discovery.tracker.on('update', (response) => {
+        // afaik only PBH-BTN/trunker and NoBrakeTracker supports this, lol
+        const raw = response['external ip'] || response.your_ip
+        if (raw) {
+          this.client._recordIP(typeof raw === 'string' ? raw : bytesToIP(raw))
+        }
+      })
+    }
 
     this.discovery.on('dhtAnnounce', () => {
       this.emit('dhtAnnounce')
@@ -1033,6 +1057,15 @@ export default class Torrent extends EventEmitter {
     this._queue = null
   }
 
+  /**
+   * Set the torrent's priority (minimum 1). Higher priority = larger share of the connection budget target.
+   * @param  {number} priority
+   */
+  setPriority (priority) {
+    this.priority = Math.max(1, Math.round(priority) || 1)
+    this._drain()
+  }
+
   addPeer (peer, source) {
     if (this.destroyed) throw new Error('torrent is destroyed')
     if (!this.infoHash) throw new Error('addPeer() must not be called before the `infoHash` event')
@@ -1114,6 +1147,7 @@ export default class Torrent extends EventEmitter {
     if (typeof peer === 'string') {
       // `peer` is an addr ("ip:port" string)
       this._queue.push(newPeer)
+      this._queue.sort((a, b) => b.bep40Priority - a.bep40Priority)
       this._drain()
     }
 
@@ -1165,12 +1199,36 @@ export default class Torrent extends EventEmitter {
   }
 
   /**
-   * Called whenever a new incoming TCP peer connects to this torrent swarm. Called with a
+   * Called whenever a new incoming peer connects to this torrent swarm. Called with a
    * peer that has already sent a handshake.
    */
   _addIncomingPeer (peer) {
     if (this.destroyed) return peer.destroy(new Error('torrent is destroyed'))
     if (this.paused) return peer.destroy(new Error('torrent is paused'))
+
+    const incomingPriority = peer.bep40Priority
+
+    if (this._numConns >= this.client.maxConns) {
+      if (incomingPriority > 0) {
+        const evict = this._findLowestPriorityPeer(incomingPriority)
+        if (evict) {
+          this._debug('evicting low-priority peer %s for incoming peer %s', evict.id, peer.id)
+          return evict.destroy()
+        }
+      }
+      return peer.destroy(new Error('torrent at max connections'))
+    }
+
+    if (this.client._totalConns + this.client._totalPending >= this.client.connectionBudget && this._numConns >= this._fairShare) {
+      if (incomingPriority > 0) {
+        const evict = this._findLowestPriorityPeer(incomingPriority)
+        if (evict) {
+          this._debug('evicting low-priority peer %s for incoming peer %s', evict.id, peer.id)
+          return evict.destroy()
+        }
+      }
+      return peer.destroy(new Error('connection budget exhausted, torrent at fair share'))
+    }
 
     this._debug('add incoming peer %s', peer.id)
 
@@ -2093,6 +2151,19 @@ export default class Torrent extends EventEmitter {
     debug(...args)
   }
 
+  _findLowestPriorityPeer (threshold) {
+    let lowestPeer = null
+    let lowestPriority = threshold
+    for (const peer of this._peers.values()) {
+      const pri = peer.bep40Priority
+      if (pri < lowestPriority) {
+        lowestPriority = pri
+        lowestPeer = peer
+      }
+    }
+    return lowestPeer
+  }
+
   /**
    * Pop a peer off the FIFO queue and connect to it. When _drain() gets called,
    * the queue will usually have only one peer in it, except when there are too
@@ -2100,11 +2171,15 @@ export default class Torrent extends EventEmitter {
    * queue until another connection closes.
    */
   _drain () {
-    this._debug('_drain numConns %s maxConns %s _peersLength %s _numPending %s', this._numConns, this.client.maxConns, this._peersLength, this._numPending)
-    if (typeof net.connect !== 'function' || this.destroyed || this.paused ||
-        this._numConns + this._numPending >= this.client.maxConns) {
-      return
-    }
+    this._debug('_drain numConns %s maxConns %s fairShare %s _peersLength %s _numPending %s', this._numConns, this.client.maxConns, this._fairShare, this._peersLength, this._numPending)
+    if (typeof net.connect !== 'function' || this.destroyed || this.paused) return
+
+    const used = this._numConns + this._numPending
+    if (used >= this.client.maxConns) return
+
+    const totalUsed = this.client._totalConns + this.client._totalPending
+    if (totalUsed >= this.client.connectionBudget && used >= this._fairShare) return
+
     this._debug('drain (%s queued, %s/%s peers)', this._numQueued, this.numPeers, this.client.maxConns)
 
     const peer = this._queue.shift()

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "throughput": "^1.0.2",
     "torrent-discovery": "^11.0.21",
     "torrent-piece": "^4.0.1",
-    "uint8-util": "^2.2.6",
+    "uint8-util": "^2.3.2",
     "unordered-array-remove": "^1.0.2",
     "ut_metadata": "^5.0.1",
     "ut_pex": "^5.0.2"

--- a/test/node/bep40.js
+++ b/test/node/bep40.js
@@ -1,0 +1,96 @@
+import test from 'tape'
+import { crc32c, computePriority, ipToBytes, bytesToIP } from '../../lib/bep40.js'
+
+test('crc32c test vectors', t => {
+  t.equal(crc32c(new Uint8Array(0)), 0x00000000, 'empty buffer')
+  t.equal(crc32c(new Uint8Array(4)), 0x48674BC7, '4 zero bytes')
+  t.equal(crc32c(new Uint8Array(8)), 0x8C28B28A, '8 zero bytes')
+  t.equal(crc32c(new TextEncoder().encode('a')), 0xC1D04330, 'string "a"')
+  t.end()
+})
+
+test('ipToBytes / bytesToIP round trip', t => {
+  t.equal(bytesToIP(ipToBytes('10.0.1.5')), '10.0.1.5', 'IPv4')
+  t.equal(bytesToIP(ipToBytes('::1')), '0:0:0:0:0:0:0:1', 'IPv6 ::1')
+  t.equal(bytesToIP(ipToBytes('2001:db8::1')), '2001:db8:0:0:0:0:0:1', 'IPv6 2001:db8::1')
+  t.equal(bytesToIP(ipToBytes('::ffff:10.0.1.1')), '10.0.1.1', 'IPv4-mapped IPv6 demoted')
+  t.end()
+})
+
+test('computePriority symmetric — swapping local/remote gives same result', t => {
+  const a = computePriority('10.0.1.5', 6881, '10.0.1.1', 6882)
+  const b = computePriority('10.0.1.1', 6882, '10.0.1.5', 6881)
+  t.equal(a, b, 'same subnet')
+
+  const c = computePriority('1.2.3.4', 6881, '5.6.7.8', 6881)
+  const d = computePriority('5.6.7.8', 6881, '1.2.3.4', 6881)
+  t.equal(c, d, 'different subnet')
+
+  const e = computePriority('10.0.1.5', 6881, '10.0.1.5', 6882)
+  const f = computePriority('10.0.1.5', 6882, '10.0.1.5', 6881)
+  t.equal(e, f, 'same IP')
+
+  const g = computePriority('::1', 6881, '::2', 6881)
+  const h = computePriority('::2', 6881, '::1', 6881)
+  t.equal(g, h, 'IPv6')
+  t.end()
+})
+
+test('computePriority same-IP falls back to port sort', t => {
+  const r1 = computePriority('10.0.1.5', 6881, '10.0.1.5', 6882)
+  const r2 = computePriority('10.0.1.5', 6882, '10.0.1.5', 6881)
+  t.equal(r1, r2, 'port order swapped gives same result')
+  t.notEqual(r1, computePriority('10.0.1.5', 6881, '10.0.1.5', 6881), 'different ports give different result')
+  t.end()
+})
+
+test('computePriority same-subnet uses /24 mask', t => {
+  // 10.0.1.5 and 10.0.1.1 share /24 -> mask = 0xFFFFFFFF -> both masked to 10.0.1.0 -> equal -> port fallback
+  const r1 = computePriority('10.0.1.5', 6881, '10.0.1.1', 6882)
+  t.equal(r1, computePriority('10.0.1.1', 6882, '10.0.1.5', 6881), 'symmetric')
+
+  const samePort = computePriority('10.0.1.5', 6881, '10.0.1.1', 6881)
+  t.equal(samePort, 0xE43A84A7, 'same port same subnet -> port buffer')
+  t.end()
+})
+
+test('computePriority different subnet', t => {
+  const r = computePriority('1.2.3.4', 6881, '5.6.7.8', 6881)
+  t.equal(r, 0x3099D763, 'known reference value')
+  t.end()
+})
+
+test('computePriority IPv6', t => {
+  const r1 = computePriority('::1', 6881, '::2', 6881)
+  const r2 = computePriority('::2', 6881, '::1', 6881)
+  t.equal(r1, r2, 'symmetric')
+  t.equal(r1, 0x78FAB5A9, 'known reference value')
+  t.end()
+})
+
+test('BEP 40 canonical test vectors', t => {
+  // From https://www.bittorrent.org/beps/bep_0040.html:
+  //   crc32-c(624C14007BD50000) -> ec2d7224
+  //   123.213.32.10 vs 98.76.54.32, diff /16 -> mask FF.FF.55.55 -> sorted masked: [98,76,20,0,123,213,0,0]
+  t.equal(computePriority('123.213.32.10', 6881, '98.76.54.32', 6881), 0xec2d7224, 'diff subnet')
+  t.equal(computePriority('98.76.54.32', 6881, '123.213.32.10', 6881), 0xec2d7224, 'diff subnet (swapped)')
+
+  //   crc32-c(7BD5200A7BD520EA) -> 99568189
+  //   123.213.32.10 vs 123.213.32.234, same /24 -> mask FF.FF.FF.FF -> sorted: [123,213,32,10,123,213,32,234]
+  t.equal(computePriority('123.213.32.10', 6881, '123.213.32.234', 6881), 0x99568189, 'same /24')
+  t.equal(computePriority('123.213.32.234', 6881, '123.213.32.10', 6881), 0x99568189, 'same /24 (swapped)')
+  t.end()
+})
+
+test('computePriority mixed IPv4 and IPv4-mapped IPv6 produces identical results', t => {
+  const ips = [
+    ['10.0.1.5', 6881, '10.0.1.1', 6881],
+    ['10.0.1.5', 6882, '::ffff:10.0.1.1', 6881],
+    ['::ffff:10.0.1.5', 6881, '10.0.1.1', 6881]
+  ]
+  const ref = computePriority('10.0.1.5', 6881, '::ffff:10.0.1.1', 6881)
+  for (const [a, pa, b, pb] of ips) {
+    t.equal(computePriority(a, pa, b, pb), ref, `${a}:${pa} vs ${b}:${pb}`)
+  }
+  t.end()
+})

--- a/test/node/ip-observation.js
+++ b/test/node/ip-observation.js
@@ -1,0 +1,391 @@
+import test from 'tape'
+import WebTorrent from '../../index.js'
+import fixtures from 'webtorrent-fixtures'
+import SimplePeer from '@thaunknown/simple-peer'
+import { bytesToIP } from '../../lib/bep40.js'
+
+test('client._recordIP tracks IP observations and picks most frequent', t => {
+  const client = new WebTorrent({ dht: false, tracker: false })
+  client.on('error', err => { t.fail(err) })
+
+  t.equal(client._bestLocalIP, null, 'no IP observed yet')
+
+  client._recordIP('10.0.0.1')
+  t.equal(client._bestLocalIP, '10.0.0.1', 'first IP becomes best')
+
+  client._recordIP('10.0.0.1')
+  t.equal(client._bestLocalIP, '10.0.0.1', 'same IP stays best')
+
+  client._recordIP('10.0.0.2')
+  t.equal(client._bestLocalIP, '10.0.0.1', '10.0.0.1 still best (2 vs 1)')
+
+  client._recordIP('10.0.0.2')
+  client._recordIP('10.0.0.2')
+  t.equal(client._bestLocalIP, '10.0.0.2', '10.0.0.2 becomes best after exceeding')
+
+  client.destroy(err => {
+    t.error(err, 'client destroyed')
+    t.end()
+  })
+})
+
+test('_recordIP ignores invalid values', t => {
+  const client = new WebTorrent({ dht: false, tracker: false })
+  client.on('error', err => { t.fail(err) })
+
+  client._recordIP(null)
+  client._recordIP(undefined)
+  client._recordIP(123)
+  client._recordIP('')
+
+  t.equal(client._bestLocalIP, null, 'invalid IPs ignored')
+
+  client.destroy(err => {
+    t.error(err, 'client destroyed')
+    t.end()
+  })
+})
+
+test('yourip sent in extended handshake to connected peer', t => {
+  t.plan(4)
+
+  const client1 = new WebTorrent({ dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false })
+  const client2 = new WebTorrent({ dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false })
+
+  client1.on('error', err => { t.fail(err) })
+  client2.on('error', err => { t.fail(err) })
+
+  client1.on('listening', () => {
+    client1.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    const torrent2 = client2.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    torrent2.on('wire', wire => {
+      wire.on('extended', (type, handshake) => {
+        if (type !== 'handshake') return
+
+        t.ok(handshake.yourip, 'received yourip in extended handshake')
+        t.equal(bytesToIP(handshake.yourip), '127.0.0.1', 'yourip is remote peers IP')
+
+        client1.destroy(err => { t.error(err, 'client1 destroyed') })
+        client2.destroy(err => { t.error(err, 'client2 destroyed') })
+      })
+    })
+
+    torrent2.on('infoHash', () => {
+      torrent2.addPeer(`127.0.0.1:${client1.address().port}`)
+    })
+  })
+})
+
+test('extended handshake yourip is recorded by receiving peer', t => {
+  t.plan(5)
+
+  const client1 = new WebTorrent({ dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false })
+  const client2 = new WebTorrent({ dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false })
+
+  client1.on('error', err => { t.fail(err) })
+  client2.on('error', err => { t.fail(err) })
+
+  client1.on('listening', () => {
+    client1.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    const torrent2 = client2.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    torrent2.on('infoHash', () => {
+      t.equal(client2._bestLocalIP, null, 'no IP observed before connection')
+
+      torrent2.addPeer(`127.0.0.1:${client1.address().port}`)
+
+      torrent2.on('wire', wire => {
+        wire.on('extended', (type, handshake) => {
+          if (type !== 'handshake') return
+          t.ok(client2._bestLocalIP, 'bestLocalIP was set after extended handshake')
+          t.equal(client2._bestLocalIP, '127.0.0.1', 'recorded IP is 127.0.0.1')
+          client1.destroy(err => { t.error(err, 'client1 destroyed') })
+          client2.destroy(err => { t.error(err, 'client2 destroyed') })
+        })
+      })
+    })
+  })
+})
+
+test('extended handshake yourip aggregated across multiple peers', t => {
+  const client1 = new WebTorrent({ dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false })
+  const client2 = new WebTorrent({ dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false })
+  const client3 = new WebTorrent({ dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false })
+
+  client1.on('error', err => { t.fail(err) })
+  client2.on('error', err => { t.fail(err) })
+  client3.on('error', err => { t.fail(err) })
+
+  client1.on('listening', () => {
+    const torrent1 = client1.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    client2.add(fixtures.leaves.parsedTorrent.infoHash)
+    client3.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    let extendedCount = 0
+    torrent1.on('wire', wire => {
+      wire.on('extended', (type, handshake) => {
+        if (type !== 'handshake') return
+        extendedCount++
+        t.pass('client1 extended handshake received')
+
+        if (extendedCount === 2) {
+          t.equal(client1._ipObservations['127.0.0.1'], 2, 'two peers reported same local IP')
+          t.equal(client1._bestLocalIP, '127.0.0.1', 'bestLocalIP set from both peers')
+          client1.destroy(() => {
+            client2.destroy(() => {
+              client3.destroy(() => {
+                t.end()
+              })
+            })
+          })
+        }
+      })
+    })
+
+    let readyCount = 0
+    const onReady = () => {
+      readyCount++
+      if (readyCount === 2) {
+        client2.torrents[0].addPeer(`127.0.0.1:${client1.address().port}`)
+        client3.torrents[0].addPeer(`127.0.0.1:${client1.address().port}`)
+      }
+    }
+    client2.torrents[0].on('infoHash', onReady)
+    client3.torrents[0].on('infoHash', onReady)
+  })
+})
+
+test('tracker update with external ip records IP via real handler', t => {
+  t.plan(4)
+
+  const client = new WebTorrent({ dht: false, lsd: false, natUpnp: false, natPmp: false })
+  client.on('error', err => { t.fail(err) })
+
+  client.on('listening', () => {
+    const torrent = client.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    torrent.on('infoHash', () => {
+      setImmediate(() => {
+        t.ok(torrent.discovery?.tracker, 'tracker exists after _startDiscovery')
+        t.equal(client._bestLocalIP, null, 'no IP observed before tracker update')
+
+        torrent.discovery.tracker.emit('update', { 'external ip': '198.51.100.2' })
+
+        t.equal(client._bestLocalIP, '198.51.100.2', 'external ip recorded via real handler')
+
+        client.destroy(err => {
+          t.error(err, 'client destroyed')
+        })
+      })
+    })
+  })
+})
+
+test('tracker update with your_ip records IP via real handler', t => {
+  t.plan(4)
+
+  const client = new WebTorrent({ dht: false, lsd: false, natUpnp: false, natPmp: false })
+  client.on('error', err => { t.fail(err) })
+
+  client.on('listening', () => {
+    const torrent = client.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    torrent.on('infoHash', () => {
+      setImmediate(() => {
+        t.ok(torrent.discovery?.tracker, 'tracker exists after _startDiscovery')
+        t.equal(client._bestLocalIP, null, 'no IP observed before tracker update')
+
+        torrent.discovery.tracker.emit('update', { your_ip: '198.51.100.3' })
+
+        t.equal(client._bestLocalIP, '198.51.100.3', 'your_ip recorded via real handler')
+
+        client.destroy(err => {
+          t.error(err, 'client destroyed')
+        })
+      })
+    })
+  })
+})
+
+test('tracker update external ip takes priority over your_ip via real handler', t => {
+  t.plan(3)
+
+  const client = new WebTorrent({ dht: false, lsd: false, natUpnp: false, natPmp: false })
+  client.on('error', err => { t.fail(err) })
+
+  client.on('listening', () => {
+    const torrent = client.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    torrent.on('infoHash', () => {
+      setImmediate(() => {
+        t.ok(torrent.discovery?.tracker, 'tracker exists after _startDiscovery')
+
+        torrent.discovery.tracker.emit('update', { 'external ip': '198.51.100.2', your_ip: '10.0.0.1' })
+
+        t.equal(client._bestLocalIP, '198.51.100.2', 'external ip preferred over your_ip')
+
+        client.destroy(err => {
+          t.error(err, 'client destroyed')
+        })
+      })
+    })
+  })
+})
+
+test('WebRTC yourip sent in extended handshake between two torrent clients', async t => {
+  const clientA = new WebTorrent({ dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false })
+  clientA.on('error', err => { t.fail(err) })
+  const clientB = new WebTorrent({ dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false })
+  clientB.on('error', err => { t.fail(err) })
+
+  await Promise.all([
+    new Promise(resolve => clientA.on('listening', resolve)),
+    new Promise(resolve => clientB.on('listening', resolve))
+  ])
+
+  const torrentA = clientA.add(fixtures.leaves.parsedTorrent.infoHash)
+  const torrentB = clientB.add(fixtures.leaves.parsedTorrent.infoHash)
+
+  await Promise.all([
+    new Promise(resolve => torrentA.on('infoHash', resolve)),
+    new Promise(resolve => torrentB.on('infoHash', resolve))
+  ])
+
+  const pA = new SimplePeer({ initiator: true })
+  const pB = new SimplePeer({})
+
+  pA.on('error', () => {})
+  pB.on('error', () => {})
+  pA.on('signal', data => pB.signal(data))
+  pB.on('signal', data => pA.signal(data))
+
+  await Promise.all([
+    new Promise(resolve => pA.on('connect', resolve)),
+    new Promise(resolve => pB.on('connect', resolve))
+  ])
+  await new Promise(resolve => setImmediate(resolve))
+
+  t.ok(pA.remoteAddress, 'pA has remoteAddress')
+  t.ok(pB.remoteAddress, 'pB has remoteAddress')
+
+  const gotExtendedB = new Promise((resolve, reject) => {
+    torrentB.on('wire', wire => {
+      wire.once('extended', (type, handshake) => {
+        if (type !== 'handshake') return
+        resolve(handshake)
+      })
+      wire.once('error', reject)
+    })
+    torrentB.on('error', reject)
+  })
+
+  torrentB.addPeer(pB)
+  torrentA.addPeer(pA)
+
+  const handshakeB = await gotExtendedB
+
+  t.ok(handshakeB.yourip, 'clientB received yourip in extended handshake')
+  t.equal(bytesToIP(handshakeB.yourip), pA.remoteAddress, 'clientB yourip is pA remoteAddress')
+
+  await Promise.all([
+    new Promise(resolve => clientA.destroy(resolve)),
+    new Promise(resolve => clientB.destroy(resolve))
+  ])
+  t.pass('clients destroyed')
+})
+
+test('WebRTC extended handshake yourip recorded on both sides', async t => {
+  const clientA = new WebTorrent({ dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false })
+  clientA.on('error', err => { t.fail(err) })
+  const clientB = new WebTorrent({ dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false })
+  clientB.on('error', err => { t.fail(err) })
+
+  await Promise.all([
+    new Promise(resolve => clientA.on('listening', resolve)),
+    new Promise(resolve => clientB.on('listening', resolve))
+  ])
+
+  const torrentA = clientA.add(fixtures.leaves.parsedTorrent.infoHash)
+  const torrentB = clientB.add(fixtures.leaves.parsedTorrent.infoHash)
+
+  await Promise.all([
+    new Promise(resolve => torrentA.on('infoHash', resolve)),
+    new Promise(resolve => torrentB.on('infoHash', resolve))
+  ])
+
+  t.equal(clientA._bestLocalIP, null, 'no IP observed on A before WebRTC connection')
+  t.equal(clientB._bestLocalIP, null, 'no IP observed on B before WebRTC connection')
+
+  const pA = new SimplePeer({ initiator: true })
+  const pB = new SimplePeer({})
+
+  pA.on('error', () => {})
+  pB.on('error', () => {})
+  pA.on('signal', data => pB.signal(data))
+  pB.on('signal', data => pA.signal(data))
+
+  await new Promise(resolve => pB.on('connect', resolve))
+
+  const gotExtendedA = new Promise((resolve, reject) => {
+    torrentA.on('wire', wire => {
+      wire.once('extended', (type, handshake) => {
+        if (type !== 'handshake') return
+        resolve(handshake)
+      })
+      wire.once('error', reject)
+    })
+    torrentA.on('error', reject)
+  })
+  const gotExtendedB = new Promise((resolve, reject) => {
+    torrentB.on('wire', wire => {
+      wire.once('extended', (type, handshake) => {
+        if (type !== 'handshake') return
+        resolve(handshake)
+      })
+      wire.once('error', reject)
+    })
+    torrentB.on('error', reject)
+  })
+
+  torrentB.addPeer(pB)
+  torrentA.addPeer(pA)
+
+  await Promise.all([gotExtendedA, gotExtendedB])
+
+  t.ok(clientA._bestLocalIP, 'bestLocalIP set on clientA after WebRTC')
+  t.equal(clientA._bestLocalIP, pB.remoteAddress, 'clientA recorded pBs remoteAddress')
+  t.ok(clientB._bestLocalIP, 'bestLocalIP set on clientB after WebRTC')
+  t.equal(clientB._bestLocalIP, pA.remoteAddress, 'clientB recorded pAs remoteAddress')
+
+  await Promise.all([
+    new Promise(resolve => clientA.destroy(resolve)),
+    new Promise(resolve => clientB.destroy(resolve))
+  ])
+  t.pass('clients destroyed')
+})
+
+test('NAT traversal externalIp recorded via _recordIP on listening', async t => {
+  const client = new WebTorrent({ dht: false, tracker: false, lsd: false, natUpnp: false, natPmp: false })
+  client.on('error', err => { t.fail(err) })
+
+  await new Promise(resolve => client.on('listening', resolve))
+
+  client.natTraversal = {
+    externalIp: () => Promise.resolve('203.0.113.5'),
+    map: () => Promise.resolve(),
+    destroy: () => Promise.resolve()
+  }
+
+  client._onListening()
+
+  await new Promise(resolve => setImmediate(resolve))
+
+  t.equal(client._bestLocalIP, '203.0.113.5', 'external IP recorded via _recordIP')
+
+  await new Promise(resolve => client.destroy(resolve))
+  t.pass('client destroyed')
+})

--- a/test/node/priority.js
+++ b/test/node/priority.js
@@ -1,0 +1,351 @@
+import { PassThrough } from 'stream'
+import test from 'tape'
+import fixtures from 'webtorrent-fixtures'
+import Peer from '../../lib/peer.js'
+import WebTorrent from '../../index.js'
+
+test('torrent.setPriority updates priority', t => {
+  const client = new WebTorrent({ dht: false, tracker: false })
+  client.on('error', err => { t.fail(err) })
+
+  const torrent = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000001', { store: false })
+
+  t.equal(torrent.priority, 1, 'default priority is 1')
+  torrent.setPriority(5)
+  t.equal(torrent.priority, 5, 'priority updated')
+
+  client.destroy(err => {
+    t.error(err, 'client destroyed')
+    t.end()
+  })
+})
+
+test('_fairShare computed dynamically from priority', t => {
+  const client = new WebTorrent({ dht: false, tracker: false, connectionBudget: 100 })
+  client.on('error', err => { t.fail(err) })
+
+  const a = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000001', { store: false })
+  const b = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000002', { store: false })
+
+  t.equal(a._fairShare, 50, 'equal priority equal fair share')
+  t.equal(b._fairShare, 50, 'equal priority equal fair share')
+
+  a.setPriority(3)
+  t.equal(a._fairShare, 90, 'p3^2=9 gets 9/10 of budget=90')
+  t.equal(b._fairShare, 10, 'p1^2=1 gets 1/10 of budget=10')
+
+  client.destroy(err => {
+    t.error(err, 'client destroyed')
+    t.end()
+  })
+})
+
+test('priority set via client.add opts', t => {
+  const client = new WebTorrent({ dht: false, tracker: false })
+  client.on('error', err => { t.fail(err) })
+
+  const torrent = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000001', { store: false, priority: 3 })
+  t.equal(torrent.priority, 3, 'priority set via opts')
+
+  client.destroy(err => {
+    t.error(err, 'client destroyed')
+    t.end()
+  })
+})
+
+test('_totalPeers and _totalPending sum across active torrents', t => {
+  const client = new WebTorrent({ dht: false, tracker: false })
+  client.on('error', err => { t.fail(err) })
+
+  t.equal(client._totalConns, 0, 'sums to 0 with no torrents')
+  t.equal(client._totalPending, 0, 'sums to 0 with no torrents')
+
+  const a = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000001', { store: false })
+  t.equal(client._totalConns, 0, 'sums to 0 with no peers')
+  t.equal(client._totalPending, 0, 'sums to 0 with no pending')
+
+  const b = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000002', { store: false })
+  a._numConns = 5
+  b._numConns = 3
+  a._numPending = 2
+  t.equal(client._totalConns, 8, 'sums _numConns across torrents')
+  t.equal(client._totalPending, 2, 'sums _numPending across torrents')
+
+  a.destroy()
+  t.equal(client._totalConns, 3, 'skips destroyed torrents')
+
+  client.destroy(err => {
+    t.error(err, 'client destroyed')
+    t.end()
+  })
+})
+
+test('_fairShare scales linearly with priority regardless of torrent count', t => {
+  const client = new WebTorrent({ dht: false, tracker: false, connectionBudget: 100 })
+  client.on('error', err => { t.fail(err) })
+
+  const high = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000001', { store: false, priority: 3 })
+
+  t.equal(high._fairShare, 100, 'p3 alone gets 100 = floor(100*3/3)')
+
+  for (let i = 0; i < 50; i++) {
+    client.add('magnet:?xt=urn:btih:' + String(i).padStart(40, '0'), { store: false, priority: 1 })
+  }
+
+  t.equal(high._fairShare, 16, 'p3 gets ceil(100*9/59)=16 with 50 p1s')
+  t.ok(high._fairShare >= 16, 'p3 share stays above 16 under p1 flood')
+
+  client.destroy(err => {
+    t.error(err, 'client destroyed')
+    t.end()
+  })
+})
+
+test('setPriority triggers _drain', t => {
+  const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
+  client.on('error', err => { t.fail(err) })
+
+  client.on('listening', () => {
+    const torrent = client.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    torrent.on('infoHash', () => {
+      const peer = Peer.createTCPOutgoingPeer('127.0.0.1:8001', torrent, client.throttleGroups, 'manual', client.secure)
+      torrent._registerPeer(peer)
+      torrent._queue.push(peer)
+
+      t.equal(torrent._queue.length, 1, 'peer queued')
+
+      torrent.setPriority(3)
+
+      t.equal(torrent._queue.length, 0, '_drain popped peer after setPriority')
+
+      client.destroy(() => t.end())
+    })
+  })
+})
+
+test('_findLowestPriorityPeer returns peer below threshold', t => {
+  const client = new WebTorrent({ dht: false, tracker: false })
+  client.on('error', err => { t.fail(err) })
+
+  const torrent = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000001', { store: false })
+
+  const p1 = { bep40Priority: 100, destroy () {} }
+  const p2 = { bep40Priority: 50, destroy () {} }
+  const p3 = { bep40Priority: 10, destroy () {} }
+  const p4 = { bep40Priority: 200, destroy () {} }
+
+  torrent._peers.set('a', p1)
+  torrent._peers.set('b', p2)
+  torrent._peers.set('c', p3)
+  torrent._peers.set('d', p4)
+
+  t.equal(torrent._findLowestPriorityPeer(60), p3, 'finds lowest priority (10) below threshold')
+  t.equal(torrent._findLowestPriorityPeer(15), p3, 'finds priority 10 below threshold 15')
+  t.equal(torrent._findLowestPriorityPeer(5), null, 'no peer below threshold 5')
+  t.equal(torrent._findLowestPriorityPeer(300), p3, 'finds lowest across all when threshold is high')
+
+  client.destroy(err => {
+    t.error(err, 'client destroyed')
+    t.end()
+  })
+})
+
+test('_addIncomingPeer evicts lowest priority peer at max connections', t => {
+  const client = new WebTorrent({ dht: false, tracker: false, lsd: false, connectionBudget: 9999 })
+  client.on('error', err => { t.fail(err) })
+
+  client.on('listening', () => {
+    const torrent = client.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    torrent.on('infoHash', () => {
+      const existing = new Peer('0.0.0.0:8001', Peer.TYPE_TCP_INCOMING, 0)
+      existing.bep40Priority = 10
+      existing.swarm = torrent
+      torrent._peers.set(existing.id, existing)
+      torrent._numConns = client.maxConns
+
+      const incoming = new Peer('10.0.0.1:9999', Peer.TYPE_TCP_INCOMING, 0)
+      incoming.bep40Priority = 9999
+      incoming.connected = true
+      incoming.swarm = torrent
+
+      torrent._addIncomingPeer(incoming)
+
+      t.ok(existing.destroyed, 'existing low-priority peer destroyed')
+      t.ok(torrent._peers.has(incoming.id), 'incoming peer registered')
+
+      client.destroy(() => t.end())
+    })
+  })
+})
+
+test('_addIncomingPeer rejects when no lower priority peer to evict', t => {
+  const client = new WebTorrent({ dht: false, tracker: false, lsd: false, connectionBudget: 9999 })
+  client.on('error', err => { t.fail(err) })
+
+  client.on('listening', () => {
+    const torrent = client.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    torrent.on('infoHash', () => {
+      const existing = new Peer('0.0.0.0:8001', Peer.TYPE_TCP_INCOMING, 0)
+      existing.bep40Priority = 100
+      existing.swarm = torrent
+      torrent._peers.set(existing.id, existing)
+      torrent._numConns = client.maxConns
+
+      const incoming = new Peer('10.0.0.1:9999', Peer.TYPE_TCP_INCOMING, 0)
+      incoming.bep40Priority = 50
+      incoming.connected = true
+      incoming.swarm = torrent
+
+      torrent._addIncomingPeer(incoming)
+
+      t.ok(incoming.destroyed, 'incoming peer destroyed when no lower priority to evict')
+
+      client.destroy(() => t.end())
+    })
+  })
+})
+
+test('_addIncomingPeer rejects zero-bep40Priority peer at max connections', t => {
+  const client = new WebTorrent({ dht: false, tracker: false, lsd: false, connectionBudget: 9999 })
+  client.on('error', err => { t.fail(err) })
+
+  client.on('listening', () => {
+    const torrent = client.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    torrent.on('infoHash', () => {
+      const existing = new Peer('0.0.0.0:8001', Peer.TYPE_TCP_INCOMING, 0)
+      existing.swarm = torrent
+      torrent._peers.set(existing.id, existing)
+      torrent._numConns = client.maxConns
+
+      const incoming = new Peer('10.0.0.1:9999', Peer.TYPE_TCP_INCOMING, 0)
+      incoming.bep40Priority = 0
+      incoming.connected = true
+      incoming.swarm = torrent
+
+      torrent._addIncomingPeer(incoming)
+
+      t.ok(incoming.destroyed, 'zero-priority incoming peer rejected')
+
+      client.destroy(() => t.end())
+    })
+  })
+})
+
+test('_queue sorted by bep40Priority descending after addPeer', t => {
+  const client = new WebTorrent({ dht: false, tracker: false, lsd: false })
+  client.on('error', err => { t.fail(err) })
+
+  client._recordIP('127.0.0.1')
+
+  client.on('listening', () => {
+    const torrent = client.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    torrent.on('infoHash', () => {
+      torrent._numConns = client.maxConns
+
+      torrent.addPeer('127.0.0.1:8001')
+      torrent.addPeer('127.0.0.1:8002')
+      torrent.addPeer('127.0.0.1:8003')
+
+      t.equal(torrent._queue.length, 3, '3 peers in queue')
+      const priorities = torrent._queue.map(p => p.bep40Priority)
+      for (let i = 1; i < priorities.length; i++) {
+        t.ok(priorities[i - 1] >= priorities[i], `queue sorted descending at index ${i}`)
+      }
+
+      client.destroy(() => t.end())
+    })
+  })
+})
+
+test('_drain respects budget gating when at fair share', t => {
+  const client = new WebTorrent({ dht: false, tracker: false, lsd: false, connectionBudget: 6 })
+  client.on('error', err => { t.fail(err) })
+
+  client.on('listening', () => {
+    const torrent = client.add(fixtures.leaves.parsedTorrent.infoHash)
+
+    torrent.on('infoHash', () => {
+      torrent._numConns = 6
+
+      const peer = Peer.createTCPOutgoingPeer('127.0.0.1:8001', torrent, client.throttleGroups, 'manual', client.secure)
+      torrent._registerPeer(peer)
+      torrent._queue.push(peer)
+
+      t.equal(torrent._queue.length, 1, 'peer queued')
+
+      torrent._drain()
+
+      t.equal(torrent._queue.length, 1, 'peer remained in queue after drain bailed')
+
+      client.destroy(() => t.end())
+    })
+  })
+})
+
+test('_fairShare proportional across multiple priority levels', t => {
+  const client = new WebTorrent({ dht: false, tracker: false, connectionBudget: 60 })
+  client.on('error', err => { t.fail(err) })
+
+  const high = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000001', { store: false, priority: 3 })
+  const mid = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000002', { store: false, priority: 2 })
+  const low = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000003', { store: false, priority: 1 })
+
+  t.equal(high._fairShare, 39, 'p3^2=9 gets ceil(60*9/14)=39')
+  t.equal(mid._fairShare, 18, 'p2^2=4 gets ceil(60*4/14)=18')
+  t.equal(low._fairShare, 5, 'p1^2=1 gets ceil(60*1/14)=5')
+
+  client.destroy(err => {
+    t.error(err, 'client destroyed')
+    t.end()
+  })
+})
+
+test('_fairShare rounds up even with tiny budget', t => {
+  const client = new WebTorrent({ dht: false, tracker: false, connectionBudget: 1 })
+  client.on('error', err => { t.fail(err) })
+
+  const a = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000001', { store: false, priority: 1 })
+  const b = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000002', { store: false, priority: 2 })
+
+  t.equal(a._fairShare, 1, 'p1^2=1 ceil(1*1/5)=1')
+  t.equal(b._fairShare, 1, 'p2^2=4 ceil(1*4/5)=1')
+
+  client.destroy(err => {
+    t.error(err, 'client destroyed')
+    t.end()
+  })
+})
+
+test('_fairShare returns 0 when torrent destroyed', t => {
+  const client = new WebTorrent({ dht: false, tracker: false })
+  client.on('error', err => { t.fail(err) })
+
+  const torrent = client.add('magnet:?xt=urn:btih:0000000000000000000000000000000000000001', { store: false })
+  torrent.destroy()
+  t.equal(torrent._fairShare, 0, 'destroyed torrent returns 0')
+
+  client.destroy(err => {
+    t.error(err, 'client destroyed')
+    t.end()
+  })
+})
+
+test('WebSeed peer bep40Priority is Infinity', t => {
+  const conn = new PassThrough()
+  conn.remoteAddress = '127.0.0.1'
+  conn.remotePort = 9999
+
+  const throttleGroups = { down: { throttle: () => new PassThrough() }, up: { throttle: () => new PassThrough() } }
+  const peer = Peer.createWebSeedPeer(conn, 'http://example.com/test', null, throttleGroups)
+
+  t.equal(peer.bep40Priority, Infinity, 'web seed peer has Infinity priority')
+  peer.wire?.on('error', () => {})
+  peer.destroy()
+
+  t.end()
+})


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Tried to add a priority based global connection budget. This isn't a strict global peer count limit, but more of a soft dynamic target. This is done mainly so WebTorrent doesn't implode itself when there are 100 torrents running at once, and to allow WebTorrent to have "actually important" torrents be prioritized, while the less important torrents can "fight" for available bandwidth.

Also fixes an issue where incoming peers didn't respect the peer limits.
**Which issue (if any) does this pull request address?**
https://github.com/webtorrent/webtorrent/issues/703
**Is there anything you'd like reviewers to focus on?**
the scaling is quite poor since N prio 1 torrents will scale down a single prio 4 torrent quite rapidly.

is there a better way to handle incoming peer, like pause the servers or smth?